### PR TITLE
Add Editor Opacity Slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       </div>
 
       <div id="controls" class="controls">
+        <label>Opacity <input id="editor-opacity" type="range" min="0" max="1" step="0.05" value="1"></label>
         <label><input id="toggle-back" type="checkbox" checked> Back rain</label>
         <label><input id="toggle-front" type="checkbox" checked> Front rain</label>
         <label><input id="toggle-front-on-top" type="checkbox" checked> Front layer on top of editor</label>

--- a/src/main.js
+++ b/src/main.js
@@ -149,3 +149,9 @@ document.getElementById('toggle-front-on-top').addEventListener('change', (e) =>
     frontCanvas.style.zIndex = 0; editorEl.style.zIndex = 1;
   }
 });
+
+const opacitySlider = document.getElementById('editor-opacity');
+opacitySlider.addEventListener('input', (e) => {
+  editorEl.style.opacity = e.target.value;
+});
+editorEl.style.opacity = opacitySlider.value;


### PR DESCRIPTION
Added a slider to the controls section to adjust the opacity of the Monaco Editor, allowing users to make the code semi-transparent and see the rain background more clearly.

---
*PR created automatically by Jules for task [13081245681214273069](https://jules.google.com/task/13081245681214273069) started by @ford442*