### PR TITLE
Add Image Viewing and Drag-and-Drop Tab Depth to 3D Cabinet

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <div id="reference-overlay"></div>
         <div id="holo-layer"></div>
         <div id="editor"></div>
+        <div id="image-viewer"></div>
         <div id="scanline-overlay"></div>
         <canvas id="rain-front" class="rain-canvas"></canvas>
         <div id="fog-layer"></div>

--- a/patch_cabinet.py
+++ b/patch_cabinet.py
@@ -1,0 +1,24 @@
+import re
+
+with open('src/Cabinet3D.js', 'r') as f:
+    content = f.read()
+
+colors_replacement = """const CATEGORY_COLORS = [
+  0x00aaff, // songs   — blue
+  0x00ffaa, // patterns — teal
+  0xff6600, // banks    — orange
+  0xffaa00, // samples  — amber
+  0xaa00ff, // shaders  — purple
+  0x00ff66, // music    — green
+  0xff0066, // images   — pink/red
+];"""
+
+content = re.sub(
+    r"const CATEGORY_COLORS = \[\n.*?\];",
+    colors_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+with open('src/Cabinet3D.js', 'w') as f:
+    f.write(content)

--- a/patch_cabinet2.py
+++ b/patch_cabinet2.py
@@ -1,0 +1,82 @@
+import re
+
+with open('src/Cabinet3D.js', 'r') as f:
+    content = f.read()
+
+# Update _detectLanguage to recognize images
+detect_replacement = """  _detectLanguage(catName, data) {
+    if (catName === 'shaders') return 'glsl';
+    if (catName === 'images') return 'image';
+    if (data.language) return data.language;
+    const name = (data.filename || data.name || '').toLowerCase();
+    if (name.endsWith('.png') || name.endsWith('.jpg') || name.endsWith('.jpeg') || name.endsWith('.gif') || name.endsWith('.webp')) return 'image';
+    if (name.endsWith('.js'))   return 'javascript';
+    if (name.endsWith('.ts'))   return 'typescript';
+    if (name.endsWith('.json')) return 'json';
+    if (name.endsWith('.py'))   return 'python';
+    if (name.endsWith('.glsl') || name.endsWith('.frag') || name.endsWith('.vert')) return 'glsl';
+    if (catName === 'songs' || catName === 'patterns' || catName === 'banks' || catName === 'music') return 'json';
+    return 'plaintext';
+  }"""
+
+content = re.sub(
+    r"  _detectLanguage\(catName, data\) \{.*?\n  \}",
+    detect_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+# Update _onFileClick to handle images differently
+click_replacement = """  _onFileClick(catIndex, fileData) {
+    const catName = STORAGE_CATEGORIES[catIndex];
+    const id      = fileData.id || fileData._id || fileData.name || 'unknown';
+    const filename = fileData.filename || fileData.name || `${catName}-${id}`;
+
+    // For images, we can construct the direct URL to the backend
+    const isImage = catName === 'images' ||
+                    filename.toLowerCase().endsWith('.png') ||
+                    filename.toLowerCase().endsWith('.jpg') ||
+                    filename.toLowerCase().endsWith('.jpeg') ||
+                    filename.toLowerCase().endsWith('.gif') ||
+                    filename.toLowerCase().endsWith('.webp');
+
+    this._hint.textContent = `Fetching ${id}…`;
+
+    if (isImage) {
+      // For images, we just construct the URL and open it directly
+      const url = `${this.storageAPI.baseUrl}/api/songs/${encodeURIComponent(id)}`;
+      this.tabManager.addFile(filename, url, 'image');
+      const newId = this.tabManager.files.length > 0
+        ? this.tabManager.files[this.tabManager.files.length - 1].id
+        : null;
+      if (newId !== null) this.tabManager.setActive(newId);
+      this.hide();
+      return;
+    }
+
+    this.storageAPI
+      .fetchFileContent(id, catName)
+      .then((data) => {
+        const content  = data.code || data.content || data.text || JSON.stringify(data, null, 2);
+        const language = this._detectLanguage(catName, data);
+        this.tabManager.addFile(filename, content, language);
+        const newId = this.tabManager.files.length > 0
+          ? this.tabManager.files[this.tabManager.files.length - 1].id
+          : null;
+        if (newId !== null) this.tabManager.setActive(newId);
+        this.hide();
+      })
+      .catch(() => {
+        this._hint.textContent = `Could not fetch file (check backend URL)`;
+      });
+  }"""
+
+content = re.sub(
+    r"  _onFileClick\(catIndex, fileData\) \{.*?\n  \}",
+    click_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+with open('src/Cabinet3D.js', 'w') as f:
+    f.write(content)

--- a/patch_html.py
+++ b/patch_html.py
@@ -1,0 +1,7 @@
+with open('index.html', 'r') as f:
+    content = f.read()
+
+content = content.replace('<div id="editor"></div>', '<div id="editor"></div>\n        <div id="image-viewer"></div>')
+
+with open('index.html', 'w') as f:
+    f.write(content)

--- a/patch_main.py
+++ b/patch_main.py
@@ -1,0 +1,48 @@
+import re
+
+with open('src/main.js', 'r') as f:
+    content = f.read()
+
+content = content.replace("const tabManager = new TabManager(editor, monaco, editorEl, tabsContainerEl);", "const imageViewerEl = document.getElementById('image-viewer');\nconst tabManager = new TabManager(editor, monaco, editorEl, tabsContainerEl, imageViewerEl);")
+
+# Update focus visuals to handle both editor and image-viewer
+focus_visuals_replacement = """    // Editor and Image Viewer
+    const targetOpacity = Math.max(0.02, targetEditorOpacity);
+    const filter = `blur(${focusDepth * 8}px)`;
+    const transform = `scale(${editorScale}) translateZ(0)`;
+
+    editorEl.style.opacity = targetOpacity;
+    editorEl.style.filter = filter;
+    editorEl.style.transform = transform;
+
+    if (document.getElementById('image-viewer')) {
+        document.getElementById('image-viewer').style.opacity = targetOpacity;
+        document.getElementById('image-viewer').style.filter = filter;
+        document.getElementById('image-viewer').style.transform = transform;
+    }"""
+
+content = re.sub(
+    r"    // Editor\n    editorEl\.style\.opacity = Math\.max\(0\.02, targetEditorOpacity\);\n    editorEl\.style\.filter = `blur\(\$\{focusDepth \* 8\}px\)`;\n    editorEl\.style\.transform = `scale\(\$\{editorScale\}\) translateZ\(0\)`;",
+    focus_visuals_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+pointer_events_replacement = """    // Pointer Events
+    if (focusDepth > 0.6) {
+        editorEl.style.pointerEvents = 'none';
+        if (document.getElementById('image-viewer')) document.getElementById('image-viewer').style.pointerEvents = 'none';
+    } else {
+        editorEl.style.pointerEvents = 'auto';
+        if (document.getElementById('image-viewer')) document.getElementById('image-viewer').style.pointerEvents = 'auto';
+    }"""
+
+content = re.sub(
+    r"    // Pointer Events\n    if \(focusDepth > 0\.6\) \{\n        editorEl\.style\.pointerEvents = 'none';\n    \} else \{\n        editorEl\.style\.pointerEvents = 'auto';\n    \}",
+    pointer_events_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+with open('src/main.js', 'w') as f:
+    f.write(content)

--- a/patch_storage.py
+++ b/patch_storage.py
@@ -1,0 +1,9 @@
+import re
+
+with open('src/StorageAPI.js', 'r') as f:
+    content = f.read()
+
+content = content.replace("export const STORAGE_CATEGORIES = ['songs', 'patterns', 'banks', 'samples', 'shaders', 'music'];", "export const STORAGE_CATEGORIES = ['songs', 'patterns', 'banks', 'samples', 'shaders', 'music', 'images'];")
+
+with open('src/StorageAPI.js', 'w') as f:
+    f.write(content)

--- a/patch_tabmanager.py
+++ b/patch_tabmanager.py
@@ -1,0 +1,92 @@
+import re
+
+with open('src/TabManager.js', 'r') as f:
+    content = f.read()
+
+constructor_replacement = """  constructor(editor, monacoApi, editorEl, tabsEl, imageViewerEl = null) {
+    this.editor = editor;
+    this.monaco = monacoApi;
+    this.editorEl = editorEl;
+    this.tabsEl = tabsEl;
+    this.imageViewerEl = imageViewerEl || document.getElementById('image-viewer');
+    this.files = [];
+    this.activeId = null;
+    this._nextId = 1;
+  }"""
+
+content = re.sub(
+    r"  constructor\(editor, monacoApi, editorEl, tabsEl\) \{.*?\._nextId = 1;\n  \}",
+    constructor_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+add_file_replacement = """  addFile(name, content = '', language = 'javascript') {
+    const id = this._nextId++;
+    const isImage = language === 'image';
+
+    let model = null;
+    if (!isImage) {
+      model = this.monaco.editor.createModel(content, language);
+    }
+
+    this.files.push({ id, name, model, depth: 1, isImage, url: isImage ? content : null });
+    this._renderTabs();
+    return id;
+  }"""
+
+content = re.sub(
+    r"  addFile\(name, content = '', language = 'javascript'\) \{.*?return id;\n  \}",
+    add_file_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+set_active_replacement = """  setActive(id) {
+    const file = this.files.find(f => f.id === id);
+    if (!file) return;
+    this.activeId = id;
+
+    if (file.isImage) {
+      this.editorEl.style.display = 'none';
+      if (this.imageViewerEl) {
+        this.imageViewerEl.style.display = 'flex';
+        this.imageViewerEl.innerHTML = `<img src="${file.url}" alt="${file.name}" />`;
+      }
+    } else {
+      if (this.imageViewerEl) {
+        this.imageViewerEl.style.display = 'none';
+      }
+      this.editorEl.style.display = 'block';
+      this.editor.setModel(file.model);
+      this.editor.focus();
+    }
+
+    this.applyDepth(file.depth);
+    this._renderTabs();
+  }"""
+
+content = re.sub(
+    r"  setActive\(id\) \{.*?this\.editor\.focus\(\);\n  \}",
+    set_active_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+apply_depth_replacement = """  applyDepth(depthLevel) {
+    const zIndex = DEPTH_Z_INDEX[depthLevel] ?? DEPTH_Z_INDEX[1];
+    this.editorEl.style.zIndex = zIndex;
+    if (this.imageViewerEl) {
+      this.imageViewerEl.style.zIndex = zIndex;
+    }
+  }"""
+
+content = re.sub(
+    r"  applyDepth\(depthLevel\) \{.*?\n  \}",
+    apply_depth_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+with open('src/TabManager.js', 'w') as f:
+    f.write(content)

--- a/patch_tabmanager_dnd.py
+++ b/patch_tabmanager_dnd.py
@@ -1,0 +1,93 @@
+import re
+
+with open('src/TabManager.js', 'r') as f:
+    content = f.read()
+
+render_tabs_replacement = """  _renderTabs() {
+    if (!this.tabsEl) return;
+    const list = this.tabsEl.querySelector('.tabs-list');
+    if (!list) return;
+    list.innerHTML = '';
+    this.files.forEach(file => {
+      const tab = document.createElement('div');
+      tab.className = 'tab-item' + (file.id === this.activeId ? ' active' : '');
+      tab.title = `${file.name} — ${DEPTH_TITLES[file.depth]}\\nDrag to change depth`;
+      tab.draggable = true;
+
+      const badge = document.createElement('span');
+      badge.className = `tab-depth-badge depth-${file.depth}`;
+      badge.title = DEPTH_TITLES[file.depth];
+      badge.textContent = DEPTH_ICONS[file.depth];
+
+      const nameEl = document.createElement('span');
+      nameEl.className = 'tab-name';
+      nameEl.textContent = file.name;
+
+      tab.appendChild(badge);
+      tab.appendChild(nameEl);
+
+      tab.addEventListener('click', () => this.setActive(file.id));
+
+      // Drag and Drop Logic
+      tab.addEventListener('dragstart', (e) => {
+        e.dataTransfer.setData('text/plain', file.id.toString());
+        tab.classList.add('dragging');
+      });
+
+      tab.addEventListener('dragend', () => {
+        tab.classList.remove('dragging');
+      });
+
+      list.appendChild(tab);
+    });
+
+    // Add dragover and drop handling to the body to catch drops anywhere
+    if (!this._dndInitialized) {
+      document.body.addEventListener('dragover', (e) => {
+        e.preventDefault(); // Necessary to allow dropping
+      });
+
+      document.body.addEventListener('drop', (e) => {
+        e.preventDefault();
+        const idStr = e.dataTransfer.getData('text/plain');
+        if (!idStr) return;
+
+        const id = parseInt(idStr, 10);
+        const file = this.files.find(f => f.id === id);
+        if (!file) return;
+
+        // Calculate new depth based on Y position
+        const y = e.clientY;
+        const h = window.innerHeight;
+
+        let newDepth = 1;
+        if (y < h * 0.33) {
+          newDepth = 2; // Top third -> Front layer
+        } else if (y > h * 0.66) {
+          newDepth = 0; // Bottom third -> Deep layer
+        } else {
+          newDepth = 1; // Middle third -> Middle layer
+        }
+
+        if (file.depth !== newDepth) {
+          file.depth = newDepth;
+          // Apply immediately if it's the active tab
+          if (file.id === this.activeId) {
+            this.applyDepth(newDepth);
+          }
+          this._renderTabs();
+        }
+      });
+      this._dndInitialized = true;
+    }
+  }"""
+
+content = re.sub(
+    r"  _renderTabs\(\) \{.*?\n  \}",
+    render_tabs_replacement,
+    content,
+    flags=re.DOTALL
+)
+
+with open('src/TabManager.js', 'w') as f:
+    f.write(content)

--- a/src/Cabinet3D.js
+++ b/src/Cabinet3D.js
@@ -24,6 +24,7 @@ const CATEGORY_COLORS = [
   0xffaa00, // samples  — amber
   0xaa00ff, // shaders  — purple
   0x00ff66, // music    — green
+  0xff0066, // images   — pink/red
 ];
 
 const CAT_CUBE_SIZE  = 1.4;   // side-length of each category cube
@@ -394,13 +395,34 @@ export class Cabinet3D {
   _onFileClick(catIndex, fileData) {
     const catName = STORAGE_CATEGORIES[catIndex];
     const id      = fileData.id || fileData._id || fileData.name || 'unknown';
+    const filename = fileData.filename || fileData.name || `${catName}-${id}`;
+
+    // For images, we can construct the direct URL to the backend
+    const isImage = catName === 'images' ||
+                    filename.toLowerCase().endsWith('.png') ||
+                    filename.toLowerCase().endsWith('.jpg') ||
+                    filename.toLowerCase().endsWith('.jpeg') ||
+                    filename.toLowerCase().endsWith('.gif') ||
+                    filename.toLowerCase().endsWith('.webp');
+
     this._hint.textContent = `Fetching ${id}…`;
+
+    if (isImage) {
+      // For images, we just construct the URL and open it directly
+      const url = `${this.storageAPI.baseUrl}/api/songs/${encodeURIComponent(id)}`;
+      this.tabManager.addFile(filename, url, 'image');
+      const newId = this.tabManager.files.length > 0
+        ? this.tabManager.files[this.tabManager.files.length - 1].id
+        : null;
+      if (newId !== null) this.tabManager.setActive(newId);
+      this.hide();
+      return;
+    }
 
     this.storageAPI
       .fetchFileContent(id, catName)
       .then((data) => {
         const content  = data.code || data.content || data.text || JSON.stringify(data, null, 2);
-        const filename = data.filename || data.name || `${catName}-${id}`;
         const language = this._detectLanguage(catName, data);
         this.tabManager.addFile(filename, content, language);
         const newId = this.tabManager.files.length > 0
@@ -422,8 +444,10 @@ export class Cabinet3D {
    */
   _detectLanguage(catName, data) {
     if (catName === 'shaders') return 'glsl';
+    if (catName === 'images') return 'image';
     if (data.language) return data.language;
     const name = (data.filename || data.name || '').toLowerCase();
+    if (name.endsWith('.png') || name.endsWith('.jpg') || name.endsWith('.jpeg') || name.endsWith('.gif') || name.endsWith('.webp')) return 'image';
     if (name.endsWith('.js'))   return 'javascript';
     if (name.endsWith('.ts'))   return 'typescript';
     if (name.endsWith('.json')) return 'json';

--- a/src/StorageAPI.js
+++ b/src/StorageAPI.js
@@ -13,7 +13,7 @@ const DEFAULT_BASE_URL =
 /**
  * Categories tracked in the remote storage.
  */
-export const STORAGE_CATEGORIES = ['songs', 'patterns', 'banks', 'samples', 'shaders', 'music'];
+export const STORAGE_CATEGORIES = ['songs', 'patterns', 'banks', 'samples', 'shaders', 'music', 'images'];
 
 export class StorageAPI {
   /**

--- a/src/TabManager.js
+++ b/src/TabManager.js
@@ -18,11 +18,12 @@ export class TabManager {
    * @param {HTMLElement} editorEl  - the #editor DOM node
    * @param {HTMLElement} tabsEl    - the #tabs-container DOM node
    */
-  constructor(editor, monacoApi, editorEl, tabsEl) {
+  constructor(editor, monacoApi, editorEl, tabsEl, imageViewerEl = null) {
     this.editor = editor;
     this.monaco = monacoApi;
     this.editorEl = editorEl;
     this.tabsEl = tabsEl;
+    this.imageViewerEl = imageViewerEl || document.getElementById('image-viewer');
     this.files = [];
     this.activeId = null;
     this._nextId = 1;
@@ -37,8 +38,14 @@ export class TabManager {
    */
   addFile(name, content = '', language = 'javascript') {
     const id = this._nextId++;
-    const model = this.monaco.editor.createModel(content, language);
-    this.files.push({ id, name, model, depth: 1 });
+    const isImage = language === 'image';
+
+    let model = null;
+    if (!isImage) {
+      model = this.monaco.editor.createModel(content, language);
+    }
+
+    this.files.push({ id, name, model, depth: 1, isImage, url: isImage ? content : null });
     this._renderTabs();
     return id;
   }
@@ -52,10 +59,24 @@ export class TabManager {
     const file = this.files.find(f => f.id === id);
     if (!file) return;
     this.activeId = id;
-    this.editor.setModel(file.model);
+
+    if (file.isImage) {
+      this.editorEl.style.display = 'none';
+      if (this.imageViewerEl) {
+        this.imageViewerEl.style.display = 'flex';
+        this.imageViewerEl.innerHTML = `<img src="${file.url}" alt="${file.name}" />`;
+      }
+    } else {
+      if (this.imageViewerEl) {
+        this.imageViewerEl.style.display = 'none';
+      }
+      this.editorEl.style.display = 'block';
+      this.editor.setModel(file.model);
+      this.editor.focus();
+    }
+
     this.applyDepth(file.depth);
     this._renderTabs();
-    this.editor.focus();
   }
 
   /**
@@ -67,6 +88,9 @@ export class TabManager {
   applyDepth(depthLevel) {
     const zIndex = DEPTH_Z_INDEX[depthLevel] ?? DEPTH_Z_INDEX[1];
     this.editorEl.style.zIndex = zIndex;
+    if (this.imageViewerEl) {
+      this.imageViewerEl.style.zIndex = zIndex;
+    }
   }
 
   /**
@@ -91,7 +115,9 @@ export class TabManager {
     this.files.forEach(file => {
       const tab = document.createElement('div');
       tab.className = 'tab-item' + (file.id === this.activeId ? ' active' : '');
-      tab.title = `${file.name} — ${DEPTH_TITLES[file.depth]}`;
+      tab.title = `${file.name} — ${DEPTH_TITLES[file.depth]}
+Drag to change depth`;
+      tab.draggable = true;
 
       const badge = document.createElement('span');
       badge.className = `tab-depth-badge depth-${file.depth}`;
@@ -104,8 +130,60 @@ export class TabManager {
 
       tab.appendChild(badge);
       tab.appendChild(nameEl);
+
       tab.addEventListener('click', () => this.setActive(file.id));
+
+      // Drag and Drop Logic
+      tab.addEventListener('dragstart', (e) => {
+        e.dataTransfer.setData('text/plain', file.id.toString());
+        tab.classList.add('dragging');
+      });
+
+      tab.addEventListener('dragend', () => {
+        tab.classList.remove('dragging');
+      });
+
       list.appendChild(tab);
     });
+
+    // Add dragover and drop handling to the body to catch drops anywhere
+    if (!this._dndInitialized) {
+      document.body.addEventListener('dragover', (e) => {
+        e.preventDefault(); // Necessary to allow dropping
+      });
+
+      document.body.addEventListener('drop', (e) => {
+        e.preventDefault();
+        const idStr = e.dataTransfer.getData('text/plain');
+        if (!idStr) return;
+
+        const id = parseInt(idStr, 10);
+        const file = this.files.find(f => f.id === id);
+        if (!file) return;
+
+        // Calculate new depth based on Y position
+        const y = e.clientY;
+        const h = window.innerHeight;
+
+        let newDepth = 1;
+        if (y < h * 0.33) {
+          newDepth = 2; // Top third -> Front layer
+        } else if (y > h * 0.66) {
+          newDepth = 0; // Bottom third -> Deep layer
+        } else {
+          newDepth = 1; // Middle third -> Middle layer
+        }
+
+        if (file.depth !== newDepth) {
+          file.depth = newDepth;
+          // Apply immediately if it's the active tab
+          if (file.id === this.activeId) {
+            this.applyDepth(newDepth);
+          }
+          this._renderTabs();
+        }
+      });
+      this._dndInitialized = true;
+    }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -120,7 +120,8 @@ const editor = monaco.editor.create(editorEl, {
 
 // Initialize TabManager
 const tabsContainerEl = document.getElementById('tabs-container');
-const tabManager = new TabManager(editor, monaco, editorEl, tabsContainerEl);
+const imageViewerEl = document.getElementById('image-viewer');
+const tabManager = new TabManager(editor, monaco, editorEl, tabsContainerEl, imageViewerEl);
 
 // Add the initial demo file and make it active (depth 1 = middle, between rain layers)
 const INITIAL_CODE = ['// rain-2 demo','function hello(){','  console.log("hello world");','}','','// @portal'].join('\n');
@@ -494,10 +495,20 @@ function updateFocusVisuals() {
     const refScale = 1 + (focusDepth * 0.08);
     const editorScale = 1 - (focusDepth * 0.05);
 
-    // Editor
-    editorEl.style.opacity = Math.max(0.02, targetEditorOpacity);
-    editorEl.style.filter = `blur(${focusDepth * 8}px)`;
-    editorEl.style.transform = `scale(${editorScale}) translateZ(0)`;
+    // Editor and Image Viewer
+    const targetOpacity = Math.max(0.02, targetEditorOpacity);
+    const filter = `blur(${focusDepth * 8}px)`;
+    const transform = `scale(${editorScale}) translateZ(0)`;
+
+    editorEl.style.opacity = targetOpacity;
+    editorEl.style.filter = filter;
+    editorEl.style.transform = transform;
+
+    if (document.getElementById('image-viewer')) {
+        document.getElementById('image-viewer').style.opacity = targetOpacity;
+        document.getElementById('image-viewer').style.filter = filter;
+        document.getElementById('image-viewer').style.transform = transform;
+    }
 
     // Reference Layer
     if (referenceLayer) {
@@ -508,8 +519,10 @@ function updateFocusVisuals() {
     // Pointer Events
     if (focusDepth > 0.6) {
         editorEl.style.pointerEvents = 'none';
+        if (document.getElementById('image-viewer')) document.getElementById('image-viewer').style.pointerEvents = 'none';
     } else {
         editorEl.style.pointerEvents = 'auto';
+        if (document.getElementById('image-viewer')) document.getElementById('image-viewer').style.pointerEvents = 'auto';
     }
 
     // Reference Overlay
@@ -911,3 +924,6 @@ document.addEventListener('mousemove', () => {
 
 // Initial scan
 scanPortals();
+
+// Expose tabManager for testing
+window.tabManager = tabManager;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1118,3 +1118,38 @@ body.theme-blueprint #rain-back, body.theme-blueprint #rain-front {
   border-color: rgba(0, 229, 255, 0.4);
   color: #fff;
 }
+
+#image-viewer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+#image-viewer img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.8);
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.1);
+}
+
+/* Drag and Drop styling for tabs */
+.tab-item[draggable=true] {
+  cursor: grab;
+}
+
+.tab-item.dragging {
+  opacity: 0.5;
+  cursor: grabbing;
+  border-color: rgba(255, 255, 255, 0.5);
+  transform: scale(1.05);
+}
+
+/* Optional visual feedback during drag over body could be added via JS class toggling */


### PR DESCRIPTION
This PR adds support for viewing images using the 3D Cabinet and StorageAPI.
- Adds an `images` category with a pink/red 3D cube in `Cabinet3D.js`
- Connects the `images` category to `StorageAPI.js` to fetch files
- Implements an `#image-viewer` layer parallel to the `#editor` inside `index.html` and styled via `styles.css`.
- Updates `TabManager.js` to track `isImage`, seamlessly toggling between Monaco Editor and `#image-viewer`.
- Implements Drag-and-Drop for tab items in `TabManager.js` to change the `depth` property (0, 1, 2) based on vertical drop position.
- Connects depth values to the UI atmospheric effects (brightness, blur, and scale).

---
*PR created automatically by Jules for task [17218143925159722254](https://jules.google.com/task/17218143925159722254) started by @ford442*