### PR TITLE
feat: Add expose mode grid and peek features for background documents

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -4,12 +4,12 @@
 
 [33mThe CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.[39m
 
-  VITE v5.4.21  ready in 514 ms
+  VITE v5.4.21  ready in 684 ms
 
   ➜  Local:   http://localhost:3000/
   ➜  Network: http://192.168.0.2:3000/
-11:02:06 AM [vite] page reload src/TabManager.js
-11:03:02 AM [vite] page reload src/TabManager.js
-11:04:34 AM [vite] page reload src/TabManager.js
-11:04:59 AM [vite] page reload src/TabManager.js
-11:05:03 AM [vite] page reload src/TabManager.js
+10:45:05 AM [vite] page reload src/TabManager.js
+10:45:20 AM [vite] page reload src/TabManager.js
+10:45:46 AM [vite] page reload index.html
+10:45:56 AM [vite] page reload src/main.js
+10:46:10 AM [vite] page reload src/TabManager.js

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
            <label title="Lantern Mode"><input id="lantern-mode" type="checkbox" checked> Lantern Mode</label>
            <label title="Ghost Mode"><input id="ghost-mode" type="checkbox"> Ghost Mode</label>
            <label title="Wiper Mode"><input id="wiper-mode" type="checkbox"> Wiper Mode</label>
+           <label title="Expose Mode"><input id="expose-mode" type="checkbox"> Expose Mode</label>
         </div>
       </div>
     </div>

--- a/src/TabManager.js
+++ b/src/TabManager.js
@@ -277,6 +277,33 @@ Drag to change depth`;
       const echoHeader = document.createElement('div');
       echoHeader.className = 'echo-header';
       echoHeader.textContent = file.name;
+
+      const peekBtn = document.createElement('button');
+      peekBtn.className = 'echo-peek-btn';
+      peekBtn.title = 'Peek Document';
+      peekBtn.textContent = '👁️';
+      echoHeader.appendChild(peekBtn);
+
+      peekBtn.addEventListener('click', (e) => {
+          e.stopPropagation(); // prevent click from making it active
+          const isPeeking = el.classList.contains('is-peeking');
+          if (isPeeking) {
+              el.classList.remove('is-peeking');
+              if (this.editorEl) this.editorEl.classList.remove('editor-peek-fade');
+          } else {
+              // Optionally un-peek others if only one peek at a time is desired:
+              // this.echoLayerEl.querySelectorAll('.is-peeking').forEach(doc => doc.classList.remove('is-peeking'));
+              el.classList.add('is-peeking');
+              if (this.editorEl) this.editorEl.classList.add('editor-peek-fade');
+
+              const rect = el.getBoundingClientRect();
+              const evt = new CustomEvent('echo-peek', {
+                detail: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+              });
+              document.dispatchEvent(evt);
+          }
+      });
+
       el.appendChild(echoHeader);
 
       // Extract text or show image placeholder
@@ -302,6 +329,28 @@ Drag to change depth`;
           const explodeY = Math.sin(angle) * radius;
           el.style.setProperty('--explode-x', `${explodeX}px`);
           el.style.setProperty('--explode-y', `${explodeY}px`);
+
+          // Expose Mode (Grid view) coordinates
+          const cols = Math.ceil(Math.sqrt(totalEchoes));
+          const rows = Math.ceil(totalEchoes / cols);
+
+          const col = index % cols;
+          const row = Math.floor(index / cols);
+
+          const exposeW = window.innerWidth * 0.7; // Spread width
+          const exposeH = window.innerHeight * 0.7; // Spread height
+
+          const spacingX = cols > 1 ? exposeW / (cols - 1) : 0;
+          const spacingY = rows > 1 ? exposeH / (rows - 1) : 0;
+
+          const offsetX = -exposeW / 2;
+          const offsetY = -exposeH / 2;
+
+          const exposeX = offsetX + (col * spacingX);
+          const exposeY = offsetY + (row * spacingY);
+
+          el.style.setProperty('--expose-tx', `${exposeX}px`);
+          el.style.setProperty('--expose-ty', `${exposeY}px`);
       }
 
       if (this.isCascadeView) {

--- a/src/main.js
+++ b/src/main.js
@@ -509,6 +509,18 @@ document.addEventListener('echo-peek', (e) => {
     }
 });
 
+// Expose Mode Logic
+const exposeToggle = document.getElementById('expose-mode');
+if (exposeToggle) {
+    exposeToggle.addEventListener('change', (e) => {
+        if (e.target.checked) {
+            document.body.classList.add('expose-active');
+        } else {
+            document.body.classList.remove('expose-active');
+        }
+    });
+}
+
 // Ghost Mode Logic
 let ghostMode = false;
 let ghostTimer = null;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1394,6 +1394,33 @@ body.x-ray-active #echo-layer {
     transition: all 0.1s ease-out;
 }
 
+/* Peek Button */
+.echo-peek-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  opacity: 0.6;
+  transition: opacity 0.2s, transform 0.2s;
+  padding: 4px;
+  margin-left: auto;
+}
+
+.echo-peek-btn:hover {
+  opacity: 1;
+  transform: scale(1.1);
+}
+
+.echo-document.is-peeking {
+  z-index: 100 !important;
+  opacity: 1 !important;
+  filter: blur(0px) !important;
+  transform: translate3d(0, 0, 200px) scale(1.1) !important;
+  box-shadow: 0 0 100px rgba(0, 229, 255, 0.8), inset 0 0 50px rgba(0, 229, 255, 0.3) !important;
+  border-color: #00e5ff !important;
+  transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
 /* Breakthrough State */
 .echo-document.breakthrough {
   transform: translate3d(var(--tx, 0px), var(--ty, 0px), 300px) scale(1.1) !important;
@@ -1440,6 +1467,31 @@ body.alt-focus-active .echo-document:hover {
   box-shadow: 0 0 40px rgba(0, 229, 255, 0.6), inset 0 0 20px rgba(0, 229, 255, 0.3);
   border-color: rgba(0, 229, 255, 0.8);
   z-index: 30;
+}
+
+/* Expose Mode */
+body.expose-active #editor {
+  opacity: 0.1 !important;
+  filter: blur(8px) !important;
+  transform: scale(0.9) translateZ(-100px) !important;
+  pointer-events: none;
+}
+
+body.expose-active .echo-document {
+  opacity: 0.8 !important;
+  filter: blur(1px) !important;
+  transform: translate3d(var(--expose-tx, 0px), var(--expose-ty, 0px), 100px) scale(0.3) !important;
+  transition: all 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
+  z-index: 20;
+}
+
+body.expose-active .echo-document:hover {
+  opacity: 1 !important;
+  filter: blur(0px) !important;
+  transform: translate3d(var(--expose-tx, 0px), var(--expose-ty, 0px), 250px) scale(0.6) !important;
+  box-shadow: 0 0 50px rgba(0, 229, 255, 0.6), inset 0 0 20px rgba(0, 229, 255, 0.3);
+  border-color: rgba(0, 229, 255, 0.8);
+  z-index: 30 !important;
 }
 
 /* Depth Swap Animation */

--- a/verification/verify.py
+++ b/verification/verify.py
@@ -1,0 +1,78 @@
+from playwright.sync_api import sync_playwright
+import time
+
+def verify_expose_mode():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # Navigate to app
+        page.goto("http://localhost:3000/")
+
+        # Wait for initialization
+        page.wait_for_timeout(2000)
+
+        # Hide atmospheric layers as per memory instructions
+        page.evaluate("""
+            document.getElementById('fog-layer').style.display = 'none';
+            document.getElementById('rain-front').style.display = 'none';
+            document.getElementById('vignette-layer').style.display = 'none';
+            document.getElementById('matrix-layer').style.display = 'none';
+        """)
+
+        # Add a few files to create echo documents
+        page.evaluate("""
+            tabManager.addFile('file1.js', 'console.log("1");', 'javascript');
+            tabManager.addFile('file2.js', 'console.log("2");', 'javascript');
+            tabManager.addFile('file3.js', 'console.log("3");', 'javascript');
+            tabManager.addFile('file4.js', 'console.log("4");', 'javascript');
+            tabManager.addFile('file5.js', 'console.log("5");', 'javascript');
+            tabManager.addFile('file6.js', 'console.log("6");', 'javascript');
+            tabManager.setActive(1); // Set main.js as active, making others echoes
+        """)
+
+        page.wait_for_timeout(1000)
+
+        # Take a screenshot before Expose mode
+        page.screenshot(path="/home/jules/verification/before_expose.png")
+
+        # Click the Expose Mode toggle in the dock
+        page.evaluate("""
+            document.getElementById('expose-mode').click();
+        """)
+
+        # Wait for animation
+        page.wait_for_timeout(1000)
+
+        # Take a screenshot after Expose mode
+        page.screenshot(path="/home/jules/verification/after_expose.png")
+
+        # Hover over one of the echoes to show peek effect
+        page.evaluate("""
+            const echoes = document.querySelectorAll('.echo-document');
+            if (echoes.length > 0) {
+                const rect = echoes[0].getBoundingClientRect();
+                const x = rect.left + rect.width / 2;
+                const y = rect.top + rect.height / 2;
+
+                // Simulate mouse enter for hover effect
+                const event = new MouseEvent('mouseenter', {
+                    view: window,
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: x,
+                    clientY: y
+                });
+                echoes[0].dispatchEvent(event);
+            }
+        """)
+
+        page.wait_for_timeout(500)
+
+        # Take a screenshot of hover state
+        page.screenshot(path="/home/jules/verification/expose_hover.png")
+
+        browser.close()
+
+if __name__ == "__main__":
+    verify_expose_mode()


### PR DESCRIPTION
This PR implements "Expose Mode" and "Peek" features to improve the UX of partially obscured background documents. Expose Mode reorganizes all background echo documents into a spread out grid via CSS variables `--expose-x` and `--expose-y`, toggled from the dock. The Peek button adds a quick way to view an obscured document in full detail without activating it.

---
*PR created automatically by Jules for task [10238527460972726267](https://jules.google.com/task/10238527460972726267) started by @ford442*