### PR TITLE
Enhance Web IDE Aesthetics and Obscured Document Interactions

### DIFF
--- a/src/ConnectionManager.js
+++ b/src/ConnectionManager.js
@@ -227,13 +227,57 @@ export class ConnectionManager {
                 }
             });
 
-            // Draw lines to matched Echo Documents
+            // Draw lines to matched Echo Documents (Semantic Depth Linking)
             if (this.echoTargets && this.echoTargets.length > 0) {
                 this.ctx.shadowColor = 'rgba(0, 229, 255, 0.8)'; // Cyan glow for echoes
                 this.echoTargets.forEach(rect => {
                     const tx = rect.left + rect.width / 2;
                     const ty = rect.top + rect.height / 2;
-                    drawFlowLine(tx, ty, true);
+
+                    // Modify appearance based on depth and hovered state
+                    // If not hovered (semantic link), use a thicker, brighter line
+                    // If hovered, use the standard cyan line
+                    const isSemantic = !rect.isHovered;
+
+                    const dist = Math.hypot(tx - x, ty - y);
+                    let opacity = Math.min(1.0, 1500 / (dist + 50));
+
+                    if (isSemantic) {
+                        // Depth-based opacity and thickness
+                        const depthBonus = Math.max(0, 1 - (rect.depthIndex * 0.1));
+                        opacity = Math.min(1.0, opacity + depthBonus * 0.3);
+                        this.ctx.strokeStyle = `rgba(0, 255, 128, ${opacity})`; // Unique green/cyan color for semantic links
+                        this.ctx.lineWidth = 2 + depthBonus;
+                        this.ctx.shadowColor = 'rgba(0, 255, 128, 0.9)';
+                    } else {
+                        this.ctx.strokeStyle = `rgba(0, 229, 255, ${opacity})`;
+                        this.ctx.lineWidth = 1.5;
+                        this.ctx.shadowColor = 'rgba(0, 229, 255, 0.8)';
+                    }
+
+                    this.ctx.beginPath();
+                    this.ctx.moveTo(x, y);
+                    const cx = (x + tx) / 2;
+                    const cy = (y + ty) / 2 - 50;
+                    this.ctx.quadraticCurveTo(cx, cy, tx, ty);
+                    this.ctx.stroke();
+
+                    // Data Flow animation
+                    const flowTime = (time * (isSemantic ? 3 : 2)) % 1; // Faster data flow for semantic links
+                    const t = flowTime; // t from 0 to 1
+
+                    const px = (1 - t) * (1 - t) * x + 2 * (1 - t) * t * cx + t * t * tx;
+                    const py = (1 - t) * (1 - t) * y + 2 * (1 - t) * t * cy + t * t * ty;
+
+                    this.ctx.save();
+                    this.ctx.setLineDash([]);
+                    this.ctx.fillStyle = `rgba(255, 255, 255, ${opacity + 0.3})`;
+                    this.ctx.shadowBlur = isSemantic ? 20 : 15;
+                    this.ctx.shadowColor = 'rgba(255, 255, 255, 1)';
+                    this.ctx.beginPath();
+                    this.ctx.arc(px, py, isSemantic ? 4 : 3, 0, Math.PI * 2);
+                    this.ctx.fill();
+                    this.ctx.restore();
                 });
             }
 

--- a/src/FogManager.js
+++ b/src/FogManager.js
@@ -50,7 +50,7 @@ export class FogManager {
     this.ctx.restore();
   }
 
-  clearFogAt(x, y, radius) {
+  clearFogAt(x, y, radius, isSpotlight = false) {
     if (!this.ctx) return;
     const rect = this.container.getBoundingClientRect();
     const relX = x - rect.left;
@@ -62,24 +62,38 @@ export class FogManager {
     // Main clear
     this.ctx.beginPath();
     this.ctx.arc(relX, relY, radius, 0, Math.PI * 2);
+
+    // Focus Spotlight effect: apply a strong, soft radial gradient mask to clear
+    if (isSpotlight) {
+        const grad = this.ctx.createRadialGradient(relX, relY, 0, relX, relY, radius);
+        grad.addColorStop(0, 'rgba(0, 0, 0, 1)');
+        grad.addColorStop(0.7, 'rgba(0, 0, 0, 0.8)');
+        grad.addColorStop(1, 'rgba(0, 0, 0, 0)');
+        this.ctx.fillStyle = grad;
+    } else {
+        this.ctx.fillStyle = 'rgba(0, 0, 0, 1)';
+    }
+
     this.ctx.fill();
 
     // Soft edge
-    this.ctx.beginPath();
-    this.ctx.arc(relX, relY, radius * 1.3, 0, Math.PI * 2);
-    this.ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
-    this.ctx.fill();
-
-    // Irregularities (droplets running)
-    // Random chance to clear a "drip" downwards
-    if (Math.random() < 0.3) {
+    if (!isSpotlight) {
         this.ctx.beginPath();
-        this.ctx.moveTo(relX, relY + radius);
-        this.ctx.lineTo(relX + (Math.random() - 0.5) * 10, relY + radius + 20 + Math.random() * 30);
-        this.ctx.lineWidth = 5;
-        this.ctx.lineCap = 'round';
-        this.ctx.strokeStyle = 'rgba(0, 0, 0, 1.0)';
-        this.ctx.stroke();
+        this.ctx.arc(relX, relY, radius * 1.3, 0, Math.PI * 2);
+        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
+        this.ctx.fill();
+
+        // Irregularities (droplets running)
+        // Random chance to clear a "drip" downwards
+        if (Math.random() < 0.3) {
+            this.ctx.beginPath();
+            this.ctx.moveTo(relX, relY + radius);
+            this.ctx.lineTo(relX + (Math.random() - 0.5) * 10, relY + radius + 20 + Math.random() * 30);
+            this.ctx.lineWidth = 5;
+            this.ctx.lineCap = 'round';
+            this.ctx.strokeStyle = 'rgba(0, 0, 0, 1.0)';
+            this.ctx.stroke();
+        }
     }
 
     this.ctx.restore();

--- a/src/TabManager.js
+++ b/src/TabManager.js
@@ -956,10 +956,10 @@ Drag to change depth`;
                       el.style.setProperty('--rot-z', '0deg');
                   }
               }
-              // Dispatch event to clear fog
+              // Focus Spotlight: Dispatch event to heavily clear fog and rain when peeking
               const rect = el.getBoundingClientRect();
               const evt = new CustomEvent('echo-peek', {
-                detail: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+                detail: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2, radius: Math.max(rect.width, rect.height) / 1.5, isFocusSpotlight: true }
               });
               document.dispatchEvent(evt);
           }

--- a/src/main.js
+++ b/src/main.js
@@ -774,8 +774,16 @@ if (wiperToggle) {
 // Ghost Peeking Custom Event Bridge
 document.addEventListener('echo-peek', (e) => {
     if (fogManager && e.detail) {
-        // Clear fog significantly where the user is peeking at an echo document
-        fogManager.clearFogAt(e.detail.x, e.detail.y, 120);
+        // Focus Spotlight logic
+        const radius = e.detail.radius || 120;
+
+        // Heavily clear fog where user is peeking
+        fogManager.clearFogAt(e.detail.x, e.detail.y, radius, e.detail.isFocusSpotlight);
+
+        // If it's the full focus spotlight, clear rain too
+        if (e.detail.isFocusSpotlight && raindrops) {
+            raindrops.clearDroplets(e.detail.x, e.detail.y, radius);
+        }
     }
 });
 
@@ -980,7 +988,17 @@ editor.onDidChangeCursorPosition((e) => {
                               // Override the tz variable to pull it physically closer before the pulse animation takes over
                               echoEl.style.setProperty('--tz-override', '1');
                               echoEl.style.setProperty('--tz', '30px');
-                              matchedEchoes.push(echoEl.getBoundingClientRect());
+
+                              // Semantic Depth Linking: Provide the depth level to the connection manager
+                              const rect = echoEl.getBoundingClientRect();
+                              matchedEchoes.push({
+                                  left: rect.left,
+                                  top: rect.top,
+                                  width: rect.width,
+                                  height: rect.height,
+                                  depthIndex: parseInt(echoEl.dataset.index || 0, 10),
+                                  isHovered: false
+                              });
                           }
                       }
                   }
@@ -990,7 +1008,15 @@ editor.onDidChangeCursorPosition((e) => {
           // Add currently hovered files for the tether feature
           echoes.forEach(echoEl => {
               if (echoEl.matches(':hover') && !echoEl.classList.contains('resonance-hit')) {
-                   matchedEchoes.push(echoEl.getBoundingClientRect());
+                   const rect = echoEl.getBoundingClientRect();
+                   matchedEchoes.push({
+                       left: rect.left,
+                       top: rect.top,
+                       width: rect.width,
+                       height: rect.height,
+                       depthIndex: parseInt(echoEl.dataset.index || 0, 10),
+                       isHovered: true
+                   });
               }
           });
 
@@ -1189,7 +1215,35 @@ document.addEventListener('keyup', (e) => {
 
 let stackZ = 0;
 window.addEventListener('wheel', (e) => {
-    if (e.altKey) {
+    // "Layered Depth Explorer" feature mapped to Shift+Alt
+    if (e.shiftKey && e.altKey && !tabManager.isCascadeView) {
+        e.preventDefault();
+        const delta = e.deltaY * 0.8; // Faster scroll
+        stackZ += delta;
+
+        // Clamp scroll stack depth roughly to available echoes with some padding
+        const maxDepth = (tabManager.files.length * 50) + 200;
+        stackZ = Math.max(-100, Math.min(maxDepth, stackZ));
+
+        if (echoLayerEl) {
+            echoLayerEl.style.setProperty('--stack-z', `${stackZ}px`);
+
+            // Highlight intersecting documents (Layered Depth Explorer visual feedback)
+            const echoes = echoLayerEl.querySelectorAll('.echo-document');
+            echoes.forEach(echo => {
+                // Original Z position (from TabManager: index * 50)
+                const docZ = parseInt(echo.dataset.index || 0) * 50;
+
+                // If stackZ is near docZ, it's intersecting the viewing plane
+                const distance = Math.abs(docZ - stackZ);
+                if (distance < 40) {
+                    echo.classList.add('z-intersect');
+                } else {
+                    echo.classList.remove('z-intersect');
+                }
+            });
+        }
+    } else if (e.altKey) {
         e.preventDefault();
         const delta = e.deltaY * 0.001;
 
@@ -1198,45 +1252,21 @@ window.addEventListener('wheel', (e) => {
 
         // Update current focus depth immediately if Alt is held
         setFocusDepth(userPreferredDepth);
-    } else if (e.shiftKey && !tabManager.isCascadeView) {
-        e.preventDefault();
-        const delta = e.deltaY * 0.5;
-        stackZ += delta;
-
-        // Clamp scroll stack depth roughly to available echoes
-        const maxDepth = (tabManager.files.length * 50) + 100;
-        stackZ = Math.max(0, Math.min(maxDepth, stackZ));
-
-        if (echoLayerEl) {
-            echoLayerEl.style.setProperty('--stack-z', `${stackZ}px`);
-
-            // Highlight intersecting documents
-            const echoes = echoLayerEl.querySelectorAll('.echo-document');
-            echoes.forEach(echo => {
-                // Original Z position (from TabManager: index * 50)
-                const docZ = parseInt(echo.dataset.index || 0) * 50;
-
-                // If stackZ is near docZ, it's intersecting the viewing plane
-                const distance = Math.abs(docZ - stackZ);
-                if (distance < 25) {
-                    echo.classList.add('z-intersect');
-                } else {
-                    echo.classList.remove('z-intersect');
-                }
-            });
-        }
     }
 }, { passive: false });
 
 document.addEventListener('keyup', (e) => {
-    if (e.key === 'Shift') {
-        stackZ = 0;
-        if (echoLayerEl) {
-            echoLayerEl.style.setProperty('--stack-z', '0px');
-            const echoes = echoLayerEl.querySelectorAll('.echo-document');
-            echoes.forEach(echo => {
-                echo.classList.remove('z-intersect');
-            });
+    if (e.key === 'Shift' || e.key === 'Alt') {
+        // Only reset if BOTH are not held
+        if (!e.shiftKey || !e.altKey) {
+            stackZ = 0;
+            if (echoLayerEl) {
+                echoLayerEl.style.setProperty('--stack-z', '0px');
+                const echoes = echoLayerEl.querySelectorAll('.echo-document');
+                echoes.forEach(echo => {
+                    echo.classList.remove('z-intersect');
+                });
+            }
         }
     }
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -364,17 +364,17 @@ textarea:focus {
   overflow: hidden;
 
   /* Enhanced Modern Glassmorphism */
-  background: linear-gradient(145deg, rgba(20, 25, 35, 0.95), rgba(10, 15, 25, 0.85));
-  backdrop-filter: blur(80px) saturate(250%);
-  -webkit-backdrop-filter: blur(80px) saturate(250%);
+  background: linear-gradient(145deg, rgba(16, 20, 30, 0.75), rgba(10, 15, 25, 0.65));
+  backdrop-filter: blur(100px) saturate(300%);
+  -webkit-backdrop-filter: blur(100px) saturate(300%);
 
-  border: 1px solid transparent; /* Replaced by animated border */
-  border-radius: 12px;
+  border: 1px solid rgba(0, 229, 255, 0.1);
+  border-radius: 16px;
   box-shadow:
-    0 50px 120px rgba(0, 0, 0, 0.95),
-    inset 0 1px 3px rgba(255, 255, 255, 0.1),
-    inset 0 0 60px rgba(255, 0, 128, 0.15),
-    0 0 30px rgba(0, 229, 255, 0.2);
+    0 60px 140px rgba(0, 0, 0, 0.98),
+    inset 0 1px 3px rgba(255, 255, 255, 0.15),
+    inset 0 0 60px rgba(255, 0, 128, 0.2),
+    0 0 40px rgba(0, 229, 255, 0.25);
 
   z-index: 20;
   color: var(--text-primary);
@@ -1334,22 +1334,22 @@ body.theme-blueprint #rain-back, body.theme-blueprint #rain-front {
   align-items: center;
   gap: 12px;
   padding: 10px 24px;
-  border-radius: 8px; /* Sharper */
+  border-radius: 10px; /* Sharper */
   cursor: pointer;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 700;
   font-family: var(--font-mono);
-  color: rgba(220, 230, 255, 0.7);
-  background: linear-gradient(135deg, rgba(20, 25, 35, 0.6), rgba(10, 15, 25, 0.4));
-  backdrop-filter: blur(24px) saturate(150%);
-  -webkit-backdrop-filter: blur(24px) saturate(150%);
-  border: 1px solid rgba(0, 229, 255, 0.2);
-  border-bottom: 2px solid rgba(0, 229, 255, 0.1);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.8), inset 0 1px 1px rgba(255, 255, 255, 0.1);
+  color: rgba(230, 240, 255, 0.85);
+  background: linear-gradient(135deg, rgba(25, 30, 45, 0.5), rgba(10, 15, 25, 0.3));
+  backdrop-filter: blur(32px) saturate(200%);
+  -webkit-backdrop-filter: blur(32px) saturate(200%);
+  border: 1px solid rgba(0, 229, 255, 0.3);
+  border-bottom: 2px solid rgba(0, 229, 255, 0.2);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.9), inset 0 1px 2px rgba(255, 255, 255, 0.15), 0 0 15px rgba(0, 229, 255, 0.1);
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   white-space: nowrap;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 1px;
 }
 .tab-item:hover {
   background: linear-gradient(135deg, rgba(30, 40, 60, 0.7), rgba(15, 20, 35, 0.5));
@@ -1502,25 +1502,25 @@ body.x-ray-active #echo-layer {
   overflow: hidden;
 
   /* Modern styling for obscured documents with noise texture */
-  background-color: rgba(10, 15, 25, 0.7);
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.15'/%3E%3C/svg%3E"), linear-gradient(135deg, rgba(20, 30, 45, 0.9), rgba(10, 15, 25, 0.4));
+  background-color: rgba(10, 15, 25, 0.5);
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.15'/%3E%3C/svg%3E"), linear-gradient(135deg, rgba(25, 35, 55, 0.8), rgba(5, 10, 20, 0.3));
   background-blend-mode: overlay;
-  backdrop-filter: blur(32px) saturate(200%);
-  -webkit-backdrop-filter: blur(32px) saturate(200%);
+  backdrop-filter: blur(48px) saturate(250%);
+  -webkit-backdrop-filter: blur(48px) saturate(250%);
 
-  border: 1px solid rgba(0, 229, 255, 0.15);
-  border-top: 1px solid rgba(0, 229, 255, 0.3);
-  border-left: 1px solid rgba(0, 229, 255, 0.25);
-  border-radius: 12px;
+  border: 1px solid rgba(0, 229, 255, 0.2);
+  border-top: 1px solid rgba(0, 229, 255, 0.4);
+  border-left: 1px solid rgba(0, 229, 255, 0.3);
+  border-radius: 16px;
   padding: 32px;
 
   /* Enhanced glowing edge and depth shadow */
   box-shadow:
-    0 30px 80px rgba(0, 0, 0, 0.95),
-    inset 0 1px 2px rgba(255, 255, 255, 0.3),
-    inset 0 0 60px rgba(0, 229, 255, 0.1),
-    inset 0 0 10px rgba(255, 255, 255, 0.05),
-    0 0 25px rgba(0, 229, 255, 0.15);
+    0 40px 100px rgba(0, 0, 0, 0.98),
+    inset 0 1px 2px rgba(255, 255, 255, 0.4),
+    inset 0 0 80px rgba(0, 229, 255, 0.15),
+    inset 0 0 15px rgba(255, 255, 255, 0.08),
+    0 0 35px rgba(0, 229, 255, 0.2);
 
   transition: all 0.5s ease-out;
 


### PR DESCRIPTION
This submission introduces a set of aesthetic and functional improvements to the web IDE, specifically leveraging the layers of partially obscured documents. 

Key changes include:
1. **Glassmorphism UI**: Improved borders, box-shadows, and typography for `.tab-item`, `.echo-document`, and `#dock` to solidify the cyberpunk aesthetic.
2. **Semantic Depth Linking**: The `ConnectionManager` now draws dynamic data stream connections (cyan/green bezier curves) from the editor cursor to matching tokens in background layers.
3. **Focus Spotlight**: Added localized visual clarity around focused/hovered background documents by dispatching enhanced `echo-peek` events that clear both fog (`FogManager`) and rain (`raindrops.clearDroplets`).
4. **Layered Depth Explorer**: Implemented a new shortcut (`Shift+Alt+Wheel`) that allows users to seamlessly scroll through the Z-depth of background documents.

All changes have been visually verified using automated Playwright tests, and code review feedback (regarding the `raindrops.clearDroplets` function and git log pollution) has been successfully resolved.

---
*PR created automatically by Jules for task [11006334201341271868](https://jules.google.com/task/11006334201341271868) started by @ford442*