### PR TITLE
Improve web IDE styling and add 3D Cylinder View

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
             <option value="wave">🌊 Wave View</option>
             <option value="black-hole">🕳️ Black Hole</option>
             <option value="rolodex">📇 Rolodex View</option>
+            <option value="cylinder">🛢️ Cylinder View</option>
           </select>
         </div>
       </div>

--- a/src/TabManager.js
+++ b/src/TabManager.js
@@ -54,6 +54,7 @@ export class TabManager {
     this.isSphereView = false;
     this.isBlackHoleView = false;
     this.isRolodexView = false;
+    this.isCylinderView = false;
   }
 
 _deactivateAllViews() {
@@ -76,6 +77,7 @@ _deactivateAllViews() {
     this.isSphereView = false;
     this.isBlackHoleView = false;
     this.isRolodexView = false;
+    this.isCylinderView = false;
 
     document.body.classList.remove(
       'waterfall-active', 
@@ -96,7 +98,8 @@ _deactivateAllViews() {
       'wave-active', 
       'sphere-active',
       'black-hole-active',
-      'rolodex-active'
+      'rolodex-active',
+      'cylinder-active'
     );
 
     [
@@ -160,6 +163,17 @@ _deactivateAllViews() {
     this._renderEchoes();
   }
 
+  toggleCylinderView() {
+    const wasActive = this.isCylinderView;
+    this._deactivateAllViews();
+    if (!wasActive) {
+      this.isCylinderView = true;
+      document.body.classList.add('cylinder-active');
+      const btn = document.getElementById('btn-cylinder-view');
+      if (btn) btn.classList.add('active');
+    }
+    this._renderEchoes();
+  }
 
   toggleSphereView() {
     const wasActive = this.isSphereView;
@@ -641,7 +655,7 @@ Drag to change depth`;
 
       // Semantic Gravity: Pull files with similar extensions or languages closer
       const fileExt = file.name.split('.').pop();
-      if ((fileExt === activeExt || file.language === activeLang) && !this.isCascadeView && !this.isOrbitView && !this.isScatteredView && !this.isIsometricView && !this.isStackView && !this.isTunnelView && !this.isGridView && !this.isHelixView && !this.isPinboardView && !this.isVortexView && !this.isConstellationView && !this.isPrismView && !this.isCoverflowView && !this.isWaveView && !this.isSphereView && !this.isRolodexView) {
+      if ((fileExt === activeExt || file.language === activeLang) && !this.isCascadeView && !this.isOrbitView && !this.isScatteredView && !this.isIsometricView && !this.isStackView && !this.isTunnelView && !this.isGridView && !this.isHelixView && !this.isPinboardView && !this.isVortexView && !this.isConstellationView && !this.isPrismView && !this.isCoverflowView && !this.isWaveView && !this.isSphereView && !this.isRolodexView && !this.isCylinderView) {
           el.classList.add('semantic-gravity-pull');
       }
 
@@ -1124,6 +1138,29 @@ Drag to change depth`;
         el.style.setProperty('--scatter-y', '0px');
         el.style.setProperty('--scatter-z', '0px');
         el.style.setProperty('--scatter-rot', '0deg');
+      } else if (this.isCylinderView) {
+        // Cylinder View: vertical carousel
+        const totalEchoes = Math.max(1, inactiveFiles.length);
+        const angle = (index / totalEchoes) * Math.PI * 2;
+        const radius = 600;
+
+        const tx = Math.sin(angle) * radius;
+        const ty = 0;
+        const tz = Math.cos(angle) * radius - 200; // offset back
+
+        // Orient planes facing outward (along Y axis)
+        const rotY = (angle * 180 / Math.PI);
+
+        el.style.setProperty('--tx', `${tx}px`);
+        el.style.setProperty('--ty', `${ty}px`);
+        el.style.setProperty('--tz', `${tz}px`);
+        el.style.setProperty('--rot-x', '0deg');
+        el.style.setProperty('--rot-y', `${rotY}deg`);
+        el.style.setProperty('--rot-z', '0deg');
+        el.style.setProperty('--scatter-x', '0px');
+        el.style.setProperty('--scatter-y', '0px');
+        el.style.setProperty('--scatter-z', '0px');
+        el.style.setProperty('--scatter-rot', '0deg');
       } else if (this.isCoverflowView) {
         // Coverflow View positions
         const totalEchoes = inactiveFiles.length;
@@ -1364,7 +1401,7 @@ Drag to change depth`;
           if (this.editorEl) {
               this.editorEl.classList.add('editor-peek-fade');
               // Bring forward while hovering the doc itself
-              if (!this.isCascadeView && !this.isOrbitView && !this.isScatteredView && !this.isHelixView && !this.isPinboardView && !this.isVortexView && !this.isPrismView && !this.isCoverflowView && !this.isWaveView && !this.isSphereView && !this.isRolodexView) {
+              if (!this.isCascadeView && !this.isOrbitView && !this.isScatteredView && !this.isHelixView && !this.isPinboardView && !this.isVortexView && !this.isPrismView && !this.isCoverflowView && !this.isWaveView && !this.isSphereView && !this.isRolodexView && !this.isCylinderView) {
                   el.style.setProperty('--tz', '100px');
               } else if (this.isOrbitView) {
                   // Push out slightly to emphasize selection in orbit view
@@ -1375,8 +1412,8 @@ Drag to change depth`;
                   // Bring forward slightly in scattered view
                   const originalZ = parseFloat(el.style.getPropertyValue('--scatter-z') || '0');
                   el.style.setProperty('--scatter-z', `${originalZ + 150}px`);
-              } else if (this.isPinboardView || this.isHelixView || this.isVortexView || this.isPrismView || this.isWaveView || this.isSphereView || this.isRolodexView) {
-                  // Pop out for pinboard/helix/vortex/prism/wave/rolodex
+              } else if (this.isPinboardView || this.isHelixView || this.isVortexView || this.isPrismView || this.isWaveView || this.isSphereView || this.isRolodexView || this.isCylinderView) {
+                  // Pop out for pinboard/helix/vortex/prism/wave/rolodex/cylinder
                   const tz = parseFloat(el.style.getPropertyValue('--tz')) || 0;
                   el.style.setProperty('--tz', `${tz + 150}px`);
                   if (this.isPinboardView || this.isVortexView) {
@@ -1487,6 +1524,14 @@ Drag to change depth`;
                   const tz = radius * Math.cos(phi) - 200;
                   el.style.setProperty('--tz', `${tz}px`);
               } else if (this.isRolodexView) {
+                  const inactiveFiles = this.files.filter(f => f.id !== this.activeId);
+                  const totalEchoes = Math.max(1, inactiveFiles.length);
+                  const index = parseInt(el.dataset.index || 0);
+                  const angle = (index / totalEchoes) * Math.PI * 2;
+                  const radius = 600;
+                  const tz = Math.cos(angle) * radius - 200;
+                  el.style.setProperty('--tz', `${tz}px`);
+              } else if (this.isCylinderView) {
                   const inactiveFiles = this.files.filter(f => f.id !== this.activeId);
                   const totalEchoes = Math.max(1, inactiveFiles.length);
                   const index = parseInt(el.dataset.index || 0);

--- a/src/main.js
+++ b/src/main.js
@@ -1018,6 +1018,7 @@ if (viewModeSelect) {
         else if (view === 'wave') tabManager.toggleWaveView();
         else if (view === 'black-hole') tabManager.toggleBlackHoleView();
         else if (view === 'rolodex') tabManager.toggleRolodexView();
+        else if (view === 'cylinder') tabManager.toggleCylinderView();
         else tabManager._deactivateAllViews(); // Default view
     });
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1355,11 +1355,11 @@ body.theme-blueprint #rain-back, body.theme-blueprint #rain-front {
   font-weight: 700;
   font-family: var(--font-mono);
   color: rgba(230, 240, 255, 0.85);
-  background: linear-gradient(135deg, rgba(25, 30, 45, 0.7), rgba(10, 15, 25, 0.5));
+  background: linear-gradient(135deg, rgba(30, 35, 50, 0.85), rgba(15, 20, 30, 0.8));
   backdrop-filter: blur(48px) saturate(200%);
   -webkit-backdrop-filter: blur(48px) saturate(200%);
-  border: 1px solid rgba(0, 229, 255, 0.4);
-  border-bottom: 2px solid rgba(0, 229, 255, 0.3);
+  border: 1px solid rgba(0, 229, 255, 0.3);
+  border-bottom: 2px solid rgba(0, 229, 255, 0.5);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.9), inset 0 1px 3px rgba(255, 255, 255, 0.3), 0 0 20px rgba(0, 229, 255, 0.2);
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   white-space: nowrap;
@@ -1367,7 +1367,7 @@ body.theme-blueprint #rain-back, body.theme-blueprint #rain-front {
   letter-spacing: 1px;
 }
 .tab-item:hover {
-  background: linear-gradient(135deg, rgba(40, 50, 70, 0.95), rgba(20, 25, 40, 0.8));
+  background: linear-gradient(135deg, rgba(50, 60, 80, 0.95), rgba(25, 30, 45, 0.8));
   border-color: rgba(0, 229, 255, 1);
   border-bottom: 2px solid rgba(0, 229, 255, 1);
   color: #fff;
@@ -1376,7 +1376,7 @@ body.theme-blueprint #rain-back, body.theme-blueprint #rain-front {
   text-shadow: 0 0 10px rgba(0, 229, 255, 1);
 }
 .tab-item.active {
-  background: linear-gradient(180deg, rgba(0, 229, 255, 0.6), rgba(0, 100, 255, 0.3));
+  background: linear-gradient(180deg, rgba(0, 229, 255, 0.8), rgba(0, 100, 255, 0.5));
   border-color: rgba(0, 229, 255, 1);
   border-bottom: 2px solid rgba(0, 229, 255, 1);
   color: #ffffff;
@@ -1532,6 +1532,23 @@ body.x-ray-active #echo-layer {
   padding: 32px;
 }
 
+.echo-document::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255, 0, 128, 0.05), rgba(0, 229, 255, 0.05));
+  opacity: 0.5;
+  z-index: 1;
+  animation: echo-gradient-shift 12s ease-in-out infinite alternate;
+}
+
+@keyframes echo-gradient-shift {
+  0% { background: linear-gradient(135deg, rgba(255, 0, 128, 0.05), rgba(0, 229, 255, 0.05)); opacity: 0.5; }
+  50% { background: linear-gradient(135deg, rgba(0, 229, 255, 0.05), rgba(255, 255, 0, 0.05)); opacity: 0.8; }
+  100% { background: linear-gradient(135deg, rgba(255, 255, 0, 0.05), rgba(255, 0, 128, 0.05)); opacity: 0.5; }
+}
+
 /* Advanced Holographic Interface Elements - Glowing Rings */
 .echo-document::before {
   content: '';
@@ -1543,6 +1560,7 @@ body.x-ray-active #echo-layer {
   animation: holo-ring-spin 20s linear infinite;
   opacity: 0;
   transition: opacity 0.3s ease;
+  z-index: 2;
 }
 
 .echo-document:hover::before {
@@ -2973,6 +2991,42 @@ body.rolodex-active .echo-document:hover {
   opacity: 1 !important;
   filter: blur(0px) !important;
   transform: translate3d(var(--tx, 0px), var(--ty, 0px), calc(var(--tz, 0px) + 200px)) rotateX(var(--rot-x, 0deg)) rotateY(var(--rot-y, 0deg)) rotateZ(0deg) scale(1.15) !important;
+  z-index: 100 !important;
+}
+
+/* Cylinder View */
+body.cylinder-active { --bio-glow-color: rgba(200, 50, 255, 0.6); --bio-glow-strong: rgba(200, 50, 255, 0.8); }
+body.cylinder-active #editor, body.cylinder-active #image-viewer {
+  transform: scale(0.65) translateY(10%) translateZ(-50px);
+  filter: blur(2px);
+  opacity: 0.7;
+  transition: all 0.7s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+body.cylinder-active #echo-layer {
+  perspective: 2500px;
+  transform-style: preserve-3d;
+  animation: cylinder-spin 40s linear infinite;
+}
+
+@keyframes cylinder-spin {
+  from { transform: rotateY(0deg); }
+  to { transform: rotateY(360deg); }
+}
+
+body.cylinder-active .echo-document {
+  opacity: 0.85;
+  filter: blur(1px);
+  cursor: pointer;
+  transform: translate3d(var(--tx, 0px), var(--ty, 0px), var(--tz, 0px)) rotateX(var(--rot-x, 0deg)) rotateY(var(--rot-y, 0deg)) rotateZ(var(--rot-z, 0deg));
+  transition: all 0.7s cubic-bezier(0.2, 0.8, 0.2, 1);
+  box-shadow: 0 0 30px rgba(200, 50, 255, 0.15), inset 0 0 10px rgba(200, 50, 255, 0.1);
+}
+
+body.cylinder-active .echo-document:hover {
+  opacity: 1 !important;
+  filter: blur(0px) !important;
+  transform: translate3d(var(--tx, 0px), var(--ty, 0px), calc(var(--tz, 0px) + 200px)) rotateX(0deg) rotateY(var(--rot-y, 0deg)) rotateZ(0deg) scale(1.15) !important;
   z-index: 100 !important;
 }
 


### PR DESCRIPTION
This commit addresses the formatting and look-and-feel of the web IDE while introducing an innovative feature utilizing partially obscured documents. It enhances the visual presentation of active and passive tabs and adds an animated background glow to obscured 3D documents. Additionally, it implements a new 'Cylinder View' mode, accessible via the dropdown, that arranges background documents into an animated, rotating 3D carousel.

---
*PR created automatically by Jules for task [2021526431895609855](https://jules.google.com/task/2021526431895609855) started by @ford442*