### PR TITLE
feat: Add Geode View, Holographic Slice mode, and Prismatic Sheen

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
             <option value="hexagon-matrix">⬡ Hexagon Matrix</option>
             <option value="kaleidoscope">👁️ Kaleidoscope View</option>
             <option value="luminescence">🌟 Luminescence View</option>
+            <option value="geode">🪨 Geode View</option>
           </select>
         </div>
       </div>

--- a/src/TabManager.js
+++ b/src/TabManager.js
@@ -132,6 +132,7 @@ export class TabManager {
     this.isDominoesView = false;
     this.isHexagonMatrixView = false;
     this.isLuminescenceView = false;
+    this.isGeodeView = false;
   }
 
   _deactivateAllViews() {
@@ -178,6 +179,7 @@ export class TabManager {
     this.isDominoesView = false;
     this.isHexagonMatrixView = false;
     this.isLuminescenceView = false;
+    this.isGeodeView = false;
 
     document.body.classList.remove(
       "waterfall-active",
@@ -219,6 +221,7 @@ export class TabManager {
       "astrolabe-active",
       "dominoes-active",
       "luminescence-active",
+      "geode-active"
     );
 
     this.isOrigamiView = false;
@@ -266,6 +269,16 @@ export class TabManager {
       document.body.classList.add("hexagon-matrix-active");
       const btn = document.getElementById("btn-hexagon-matrix-view");
       if (btn) btn.classList.add("active");
+    }
+    this._renderEchoes();
+  }
+
+  toggleGeodeView() {
+    const wasActive = this.isGeodeView;
+    this._deactivateAllViews();
+    if (!wasActive) {
+      this.isGeodeView = true;
+      document.body.classList.add("geode-active");
     }
     this._renderEchoes();
   }
@@ -1858,6 +1871,33 @@ Drag to change depth`;
         el.style.setProperty("--rot-x", `${rotX}deg`);
         el.style.setProperty("--rot-y", `0deg`);
         el.style.setProperty("--rot-z", `0deg`);
+      } else if (this.isGeodeView) {
+        // Geode View: Arranged inside a hollow sphere, facing inward
+        // with crystalline angular variations
+        const phi = Math.acos(1 - (2 * (index + 0.5)) / totalEchoes);
+        const theta = Math.PI * (1 + Math.sqrt(5)) * index;
+        const radius = 500;
+
+        // Random angular jitter for crystalline look
+        const jitterRotX = (Math.random() - 0.5) * 45;
+        const jitterRotY = (Math.random() - 0.5) * 45;
+        const jitterRotZ = (Math.random() - 0.5) * 45;
+
+        const tx = radius * Math.sin(phi) * Math.cos(theta);
+        const ty = radius * Math.sin(phi) * Math.sin(theta);
+        const tz = radius * Math.cos(phi) - 300;
+
+        // Face inward, opposite of Luminescence view
+        const rotX = -((phi * 180) / Math.PI - 90) + jitterRotX;
+        const rotY = -((theta * 180) / Math.PI) + jitterRotY;
+        const rotZ = jitterRotZ;
+
+        el.style.setProperty("--tx", `${tx}px`);
+        el.style.setProperty("--ty", `${ty}px`);
+        el.style.setProperty("--tz", `${tz}px`);
+        el.style.setProperty("--rot-x", `${rotX}deg`);
+        el.style.setProperty("--rot-y", `${rotY}deg`);
+        el.style.setProperty("--rot-z", `${rotZ}deg`);
       } else if (this.isLuminescenceView) {
         // Luminescence View: Floating sphere with glowing colors based on extension
         // Using golden ratio spiral for even distribution on a sphere

--- a/src/main.js
+++ b/src/main.js
@@ -1748,6 +1748,7 @@ if (viewModeSelect) {
     else if (view === "dominoes") tabManager.toggleDominoesView();
     else if (view === "hexagon-matrix") tabManager.toggleHexagonMatrixView();
     else if (view === "luminescence") tabManager.toggleLuminescenceView();
+    else if (view === "geode") tabManager.toggleGeodeView();
     else tabManager._deactivateAllViews(); // Default view
   });
 }
@@ -3269,6 +3270,14 @@ document.addEventListener("mousemove", () => {
 // Initial scan
 scanPortals();
 
+// Holographic Slice Mode (Alt + Shift + S)
+document.addEventListener("keydown", (e) => {
+  if (e.altKey && e.shiftKey && e.code === "KeyS" && !e.ctrlKey && !e.metaKey) {
+    e.preventDefault();
+    document.body.classList.toggle("holographic-slice-active");
+  }
+});
+
 // X-Ray Mode (Alt + Shift + X)
 document.addEventListener("keydown", (e) => {
   if (e.altKey && e.shiftKey && e.code === "KeyX" && !e.ctrlKey && !e.metaKey) {
@@ -3700,10 +3709,18 @@ document.addEventListener("keyup", (e) => {
   if (e.key === "f" || e.key === "F" || e.key === "Alt" || e.key === "Shift") {
     document.body.classList.remove("focus-torch-active");
   }
+
+  if (e.key === "s" || e.key === "S" || e.key === "Alt" || e.key === "Shift") {
+    document.body.classList.remove("holographic-slice-active");
+  }
 });
 
 // Calculate normalized mouse X for Curtain Pull and Fabric Tear
 document.addEventListener("mousemove", (e) => {
+  if (document.body.classList.contains("holographic-slice-active")) {
+    document.body.style.setProperty("--mouse-x", `${e.clientX}px`);
+    document.body.style.setProperty("--mouse-y", `${e.clientY}px`);
+  }
   if (document.body.classList.contains("curtain-pull-active")) {
     // Normalize mouse X from -1 to 1 based on screen width
     const normX = (e.clientX / window.innerWidth) * 2 - 1;

--- a/src/styles.css
+++ b/src/styles.css
@@ -6286,18 +6286,30 @@ body.solar-system-active #echo-layer::before {
   position: absolute;
   top: 0;
   left: -100%;
-  width: 50%;
+  width: 100%;
   height: 100%;
   background: linear-gradient(
-    to right,
+    120deg,
     transparent,
-    rgba(255, 255, 255, 0.3),
+    rgba(255, 0, 0, 0.15),
+    rgba(0, 255, 0, 0.15),
+    rgba(0, 0, 255, 0.15),
     transparent
   );
+  background-size: 200% 100%;
   transform: skewX(-20deg);
-  animation: sheen 5s infinite;
+  animation: sheen 5s infinite, prismatic-pan 8s linear infinite;
   pointer-events: none;
   z-index: 1;
+}
+
+@keyframes prismatic-pan {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
 }
 
 @keyframes sheen {
@@ -7921,4 +7933,71 @@ body.depth-beam-active #depth-beam {
   opacity: 0.8;
   filter: blur(2px);
   transition: all 0.5s ease;
+}
+
+/* Geode View */
+body.geode-active .echo-document {
+  transition: all 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transform:
+    translate3d(var(--tx, 0px), var(--ty, 0px), var(--tz, 0px))
+    rotateX(var(--rot-x, 0deg))
+    rotateY(var(--rot-y, 0deg))
+    rotateZ(var(--rot-z, 0deg))
+    scale(0.8);
+
+  /* Crystalline appearance */
+  background: rgba(20, 15, 30, 0.7);
+  border: 1px solid rgba(180, 100, 255, 0.5);
+  box-shadow:
+    0 0 20px rgba(180, 100, 255, 0.3),
+    inset 0 0 30px rgba(180, 100, 255, 0.2);
+  backdrop-filter: blur(10px);
+  clip-path: polygon(5% 0%, 95% 0%, 100% 5%, 100% 95%, 95% 100%, 5% 100%, 0% 95%, 0% 5%);
+}
+
+body.geode-active .echo-document:hover {
+  transform:
+    translate3d(calc(var(--tx, 0px) * 0.9), calc(var(--ty, 0px) * 0.9), calc(var(--tz, 0px) + 100px))
+    rotateX(calc(var(--rot-x, 0deg) * 0.5))
+    rotateY(calc(var(--rot-y, 0deg) * 0.5))
+    rotateZ(0deg)
+    scale(1.1);
+
+  /* Iridescent inner glow on hover */
+  background: rgba(40, 20, 60, 0.85);
+  border-color: rgba(220, 150, 255, 0.9);
+  box-shadow:
+    0 0 40px rgba(220, 150, 255, 0.6),
+    inset 0 0 50px rgba(100, 200, 255, 0.4);
+  z-index: 100;
+}
+
+/* Holographic Slice Mode */
+body.holographic-slice-active .echo-document {
+  /* Slice based on mouse coordinates */
+  clip-path: polygon(
+    0% 0%,
+    100% 0%,
+    100% calc(var(--mouse-y, 50%) - 50px),
+    calc(var(--mouse-x, 50%) + 100px) calc(var(--mouse-y, 50%) + 50px),
+    calc(var(--mouse-x, 50%) - 100px) calc(var(--mouse-y, 50%) + 50px),
+    0% calc(var(--mouse-y, 50%) - 50px)
+  );
+  transition: clip-path 0.1s ease-out;
+  border-bottom: 2px solid rgba(0, 255, 200, 0.8);
+  box-shadow: 0 5px 25px rgba(0, 255, 200, 0.4);
+}
+
+body.holographic-slice-active #editor {
+  clip-path: polygon(
+    0% calc(var(--mouse-y, 50%) - 50px),
+    calc(var(--mouse-x, 50%) - 100px) calc(var(--mouse-y, 50%) + 50px),
+    calc(var(--mouse-x, 50%) + 100px) calc(var(--mouse-y, 50%) + 50px),
+    100% calc(var(--mouse-y, 50%) - 50px),
+    100% 100%,
+    0% 100%
+  );
+  transition: clip-path 0.1s ease-out;
+  border-top: 2px solid rgba(0, 255, 200, 0.8);
+  box-shadow: 0 -5px 25px rgba(0, 255, 200, 0.4);
 }


### PR DESCRIPTION
This commit introduces new 3D layout and interaction features utilizing the depth layers of the Web IDE.

Changes:
1. **Geode View:** A new 3D layout accessible via the dropdown that positions background document echoes on the inner surface of a hollow sphere with randomized angular jitter to simulate a crystalline geode structure.
2. **Holographic Slice Mode:** A new interaction mode toggled via `Alt + Shift + S`. When active, moving the mouse applies dynamic CSS `clip-path` calculations (using updated CSS custom properties `--mouse-x` and `--mouse-y`) to "slice" through both the main editor and the background documents.
3. **Prismatic Sheen:** Improved the aesthetic of the dock and tabs container by applying a continuous, multi-color gradient `@keyframes` animation (`prismatic-pan`) to the `.ui-sheen` elements.

---
*PR created automatically by Jules for task [7686082530470097473](https://jules.google.com/task/7686082530470097473) started by @ford442*