### PR TITLE
Enhance Peel Reveal Interaction with Realistic Curled Edge

### DIFF
--- a/src/TabManager_0.js
+++ b/src/TabManager_0.js
@@ -184,6 +184,10 @@ export const TabManagerMixin0 = {
       this.isCardSpreadView = true;
       document.body.classList.add("card-spread-active");
       const btn = document.getElementById("btn-card-spread-view");
+      if (btn) btn.classList.add("active");
+    }
+    this._renderEchoes();
+  },
   toggleMeteorView() {
     const wasActive = this.isMeteorView;
     this._deactivateAllViews();

--- a/src/main_init_4.js
+++ b/src/main_init_4.js
@@ -624,16 +624,44 @@ document.addEventListener("keydown", (e) => {
 });
 
 // Peel Reveal logic
+let isPeeling = false;
+
 document.addEventListener("keydown", (e) => {
   if (e.altKey && e.shiftKey && e.key.toLowerCase() === "v" && !e.ctrlKey && !e.metaKey) {
     e.preventDefault();
     document.body.classList.add("peel-reveal-active");
+    document.body.style.setProperty("--peel-x", `100vw`);
+    document.body.style.setProperty("--peel-y", `0px`);
   }
 });
 
 document.addEventListener("keyup", (e) => {
   if (e.key.toLowerCase() === "v" || e.key === "Alt" || e.key === "Shift") {
     document.body.classList.remove("peel-reveal-active");
+    isPeeling = false;
+  }
+});
+
+document.addEventListener("mousedown", (e) => {
+  if (document.body.classList.contains("peel-reveal-active")) {
+    isPeeling = true;
+    document.body.style.setProperty("--peel-x", `${e.clientX}px`);
+    document.body.style.setProperty("--peel-y", `${e.clientY}px`);
+  }
+});
+
+document.addEventListener("mousemove", (e) => {
+  if (isPeeling && document.body.classList.contains("peel-reveal-active")) {
+    document.body.style.setProperty("--peel-x", `${e.clientX}px`);
+    document.body.style.setProperty("--peel-y", `${e.clientY}px`);
+  }
+});
+
+document.addEventListener("mouseup", () => {
+  if (isPeeling) {
+    isPeeling = false;
+    document.body.style.setProperty("--peel-x", `100vw`);
+    document.body.style.setProperty("--peel-y", `0px`);
   }
 });
 

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -926,23 +926,23 @@ body.peel-reveal-active .echo-document {
 }
 
 body.peel-reveal-active .echo-document:not(:hover) {
-  /* Slice off the top right corner based on mouse position relative to viewport */
-  /* This creates a diagonal line that follows the cursor */
   clip-path: polygon(
     0% 0%,
-    calc(var(--mouse-x, 100%) - 50px) 0%,
-    100% calc(var(--mouse-y, 0px) + 50px),
+    var(--peel-x, 100vw) 0%,
+    calc(var(--peel-x, 100vw) - 60px) calc(var(--peel-y, 0px) * 0.5 + 20px),
+    calc(var(--peel-x, 100vw) - 20px) calc(var(--peel-y, 0px) + 50px),
+    100% calc(var(--peel-y, 0px) + 150px),
     100% 100%,
     0% 100%
   );
-  filter: drop-shadow(-5px 5px 15px rgba(0, 0, 0, 0.8));
+  filter: drop-shadow(-10px 10px 20px rgba(0, 0, 0, 0.9));
 }
 
 body.peel-reveal-active #editor {
   clip-path: polygon(
     0% 0%,
-    calc(var(--mouse-x, 100%) - 100px) 0%,
-    100% calc(var(--mouse-y, 0px) + 100px),
+    calc(var(--peel-x, 100vw) - 100px) 0%,
+    100% calc(var(--peel-y, 0px) + 150px),
     100% 100%,
     0% 100%
   );
@@ -958,26 +958,35 @@ body.peel-reveal-active .echo-document:hover {
   box-shadow: 0 0 30px rgba(0, 229, 255, 0.4) !important;
 }
 
-/* Add a curled edge effect */
-body.peel-reveal-active .echo-document::before {
+/* Curled edge effect */
+body.peel-reveal-active .echo-document::after {
   content: "";
-  position: absolute;
+  position: fixed;
   top: 0;
-  right: 0;
-  width: 100%;
-  height: 100%;
+  left: 0;
+  width: 250px;
+  height: 250px;
+  transform-origin: center;
   pointer-events: none;
-  background: linear-gradient(
-    225deg,
-    rgba(255, 255, 255, 0.4) 0%,
-    transparent 100px
+  background: radial-gradient(
+    circle at top right,
+    rgba(255, 255, 255, 0.8) 0%,
+    rgba(0, 0, 0, 0.5) 50%,
+    transparent 80%
   );
-  z-index: 10;
+  box-shadow: -15px 15px 25px rgba(0, 0, 0, 0.7);
+  border-bottom-left-radius: 100%;
+  border-top-right-radius: 20%;
+  transform: translate(
+    calc(var(--peel-x, 100vw) - 125px),
+    calc(var(--peel-y, 0px) - 50px)
+  ) rotateZ(35deg);
+  z-index: 15;
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity 0.2s, transform 0.05s linear;
 }
 
-body.peel-reveal-active .echo-document:not(:hover)::before {
+body.peel-reveal-active .echo-document:not(:hover)::after {
   opacity: 1;
 }
 
@@ -1257,6 +1266,7 @@ body.card-spread-active .echo-document:hover {
     0 0 20px rgba(0, 255, 255, 0.4),
     inset 0 0 10px rgba(255,255,255,0.2);
   z-index: 100 !important;
+}
 /* Meteor Scatter View active styles */
 body.meteor-active {
   --bio-glow-color: rgba(255, 120, 50, 0.6);


### PR DESCRIPTION
This PR improves the "Peel Reveal" (Alt+Shift+V) feature. It adds JavaScript mouse drag tracking to smoothly update `--peel-x` and `--peel-y` variables. These variables are used in updated `src/styles_14.css` rules to draw a curved document tear using `clip-path` and render a highly realistic, interactive curling page edge with shadow and highlights using a fixed-position pseudo-element. It also fixes two pre-existing syntax errors that were breaking the production build.

---
*PR created automatically by Jules for task [2046621774565232994](https://jules.google.com/task/2046621774565232994) started by @ford442*