### PR TITLE
feat: Add Focus Pull Interaction and Stack Deck hover improvements

### DIFF
--- a/src/TabManager_0.js
+++ b/src/TabManager_0.js
@@ -186,6 +186,9 @@ export const TabManagerMixin0 = {
     if (!wasActive) {
       this.isChronoRingView = true;
       document.body.classList.add("chrono-ring-active");
+    }
+    this._renderEchoes();
+  },
   toggleDnaHelixView() {
     const wasActive = this.isDnaHelixView;
     this._deactivateAllViews();

--- a/src/main_init_4.js
+++ b/src/main_init_4.js
@@ -148,6 +148,14 @@ document.addEventListener("keydown", (e) => {
     return;
   }
 
+  // Innovate: Focus Pull Interaction (Alt + F)
+  if (e.altKey && e.code === "KeyF" && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
+    e.preventDefault();
+    if (!document.body.classList.contains("focus-pull-active")) {
+      document.body.classList.add("focus-pull-active");
+    }
+  }
+
   // Depth X-Ray Scan (Alt + Z)
   if (e.altKey && e.code === "KeyZ" && !e.ctrlKey && !e.shiftKey) {
     e.preventDefault();
@@ -277,6 +285,11 @@ document.addEventListener("keydown", (e) => {
 });
 
 document.addEventListener("keyup", (e) => {
+  // Innovate: Focus Pull Interaction (Alt + F)
+  if (e.key === "f" || e.key === "F" || e.key === "Alt") {
+    document.body.classList.remove("focus-pull-active");
+  }
+
   if (e.key === "c" || e.key === "C" || e.key === "Alt") {
     if (isFanningActive && (!e.altKey || (e.code === "KeyC" && !e.altKey))) {
       isFanningActive = false;

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -1035,11 +1035,30 @@ body.stack-deck-active .echo-document {
 
 body.stack-deck-active .echo-document:hover {
   border-color: rgba(0, 229, 255, 0.8) !important;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.8), 0 0 20px rgba(0, 229, 255, 0.4), inset 0 2px 10px rgba(255, 255, 255, 0.2) !important;
-  transform: translate3d(var(--tx, 0), calc(var(--ty, 0) - 20px), calc(var(--tz, 0) + 20px))
-    rotateX(0deg) rotateY(0deg) scale(1.05) !important;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.8), 0 0 20px rgba(0, 229, 255, 0.4), inset 0 2px 10px rgba(255, 255, 255, 0.2) !important;
+  transform: translate3d(calc(var(--tx, 0) - 15px), calc(var(--ty, 0) - 15px), calc(var(--tz, 0) + 20px)) scale(1.02) !important;
   z-index: 1000 !important;
   opacity: 1 !important;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s, box-shadow 0.3s !important;
+}
+
+/* Innovate: Focus Pull Interaction (Alt + F) */
+body.focus-pull-active .echo-document {
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s ease, filter 0.4s ease;
+}
+
+body.focus-pull-active .echo-document:hover {
+  transform: translate3d(var(--tx, 0), var(--ty, 0), 100px) scale(1.1) !important;
+  z-index: 9999 !important;
+  opacity: 1 !important;
+  filter: blur(0px) brightness(1.2) !important;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.9), 0 0 40px rgba(0, 229, 255, 0.5), inset 0 0 10px rgba(255, 255, 255, 0.3) !important;
+}
+
+body.focus-pull-active .echo-document:not(:hover) {
+  opacity: 0.1 !important;
+  filter: blur(8px) grayscale(50%) !important;
+  transform: translate3d(var(--tx, 0), var(--ty, 0), calc(var(--tz, 0) - 100px)) scale(0.9) !important;
 }
 
 /* Matrix Dissolve Reveal (Alt+Y) */
@@ -1388,6 +1407,7 @@ body.magnetic-sep-active .echo-document:not(:hover) {
   /* Push non-hovered documents away. A simple hack is adding a translate X based on mouse X */
   translate: calc((var(--mouse-x, 50vw) - 50vw) * 0.2) calc((var(--mouse-y, 50vh) - 50vh) * 0.2) -50px;
   opacity: 0.3;
+}
 body.dna-helix-active .echo-document {
   transition: transform 1.2s cubic-bezier(0.2, 0.8, 0.2, 1), opacity 0.8s ease;
   opacity: 0.85;


### PR DESCRIPTION
Added a new Focus Pull Interaction feature and improved the stack deck hover state.

- **Stack Deck Hover:** Added a "Lift-and-Spread" interaction that scales and shifts the hovered document in the stack deck view for better readability.
- **Focus Pull Interaction:** Implemented a new view mode toggled with `Alt + F`. When active, hovering over a document will pull it to the forefront, while all other documents are blurred, grayscaled, and pushed backwards.
- **Bug Fixes:** Resolved syntax errors (missing closing braces) in `src/TabManager_0.js` and `src/styles_14.css` that were causing build failures.

All changes have been successfully built and verified.

---
*PR created automatically by Jules for task [7110183957838488857](https://jules.google.com/task/7110183957838488857) started by @ford442*