### PR TITLE
Enhance Outline and Stack Deck View aesthetics

### DIFF
--- a/src/styles_12.css
+++ b/src/styles_12.css
@@ -154,35 +154,42 @@ body.hologram-preview-active #echo-layer .echo-document:not(.hologram-target) {
 
 /* Enhanced tab active appearance in outline mode */
 body.outline-active .tab-item.active {
-  background: rgba(0, 229, 255, 0.15);
+  background: rgba(0, 229, 255, 0.25);
   border-bottom: 2px solid #00e5ff;
-  box-shadow: 0 0 20px rgba(0, 229, 255, 0.2);
+  box-shadow: 0 0 25px rgba(0, 229, 255, 0.4);
 }
 
 body.outline-active .tab-depth-badge.depth-2 {
   color: #fff;
-  text-shadow: 0 0 10px rgba(0, 229, 255, 0.9);
+  text-shadow: 0 0 12px rgba(0, 229, 255, 1);
 }
 
 /* Echo documents get stronger outlines in outline view */
 body.outline-active .echo-document {
-  border: 1px solid hsla(var(--echo-tint, 180deg), 100%, 60%, 0.55);
+  border: 1px solid hsla(var(--echo-tint, 180deg), 100%, 70%, 0.65);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.4),
-    0 0 0 1px hsla(var(--echo-tint, 180deg), 100%, 60%, 0.25),
-    inset 0 0 24px hsla(var(--echo-tint, 180deg), 100%, 60%, 0.1);
-  opacity: calc(var(--base-opacity, 0.4) + 0.15);
-  filter: blur(calc(var(--base-blur, 4px) * 0.6))
+    0 8px 32px rgba(0, 0, 0, 0.5),
+    0 0 0 1px hsla(var(--echo-tint, 180deg), 100%, 60%, 0.35),
+    inset 0 0 30px hsla(var(--echo-tint, 180deg), 100%, 60%, 0.15);
+  opacity: calc(var(--base-opacity, 0.4) + 0.2);
+  filter: blur(calc(var(--base-blur, 4px) * 0.5))
     hue-rotate(var(--echo-tint, 0deg));
+  backdrop-filter: blur(10px) saturate(160%);
+  background: linear-gradient(135deg, rgba(15, 20, 25, 0.6), rgba(5, 10, 15, 0.8));
+  border-radius: 12px;
+  transform: scale(0.95);
+  transition: all 0.4s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 body.outline-active .echo-document:hover {
-  border-color: hsla(var(--echo-tint, 180deg), 100%, 70%, 0.85) !important;
+  border-color: hsla(var(--echo-tint, 180deg), 100%, 80%, 1) !important;
   box-shadow:
-    0 12px 40px rgba(0, 0, 0, 0.5),
-    0 0 0 2px hsla(var(--echo-tint, 180deg), 100%, 70%, 0.5),
-    0 0 30px hsla(var(--echo-tint, 180deg), 100%, 60%, 0.2),
-    inset 0 0 30px hsla(var(--echo-tint, 180deg), 100%, 60%, 0.15) !important;
+    0 15px 45px rgba(0, 0, 0, 0.6),
+    0 0 0 2px hsla(var(--echo-tint, 180deg), 100%, 80%, 0.6),
+    0 0 40px hsla(var(--echo-tint, 180deg), 100%, 70%, 0.3),
+    inset 0 0 40px hsla(var(--echo-tint, 180deg), 100%, 70%, 0.2) !important;
+  transform: scale(1.02) translateY(-10px) !important;
+  z-index: 1000 !important;
 }
 
 /* Animated neon border in outline mode */
@@ -260,20 +267,28 @@ body.outline-active .echo-header::before {
 /* Symbol Outline panel */
 .echo-symbol-outline {
   margin: 8px 0 6px;
-  border: 1px solid hsla(var(--echo-tint, 180deg), 80%, 55%, 0.3);
-  border-radius: 10px;
-  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid hsla(var(--echo-tint, 180deg), 90%, 65%, 0.4);
+  border-radius: 12px;
+  background: rgba(10, 15, 25, 0.65);
+  backdrop-filter: blur(8px) saturate(120%);
   overflow: hidden;
   flex-shrink: 0;
   transition:
-    max-height 0.3s ease,
-    opacity 0.3s ease;
+    max-height 0.4s cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 0.4s ease,
+    box-shadow 0.4s ease;
   max-height: 300px;
   opacity: 1;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4);
+}
+
+.echo-symbol-outline:hover {
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.6), 0 0 15px hsla(var(--echo-tint, 180deg), 70%, 50%, 0.2);
+  border-color: hsla(var(--echo-tint, 180deg), 100%, 75%, 0.6);
 }
 
 .echo-symbol-outline[data-collapsed="true"] {
-  max-height: 32px;
+  max-height: 36px;
 }
 
 .echo-symbol-outline[data-collapsed="true"] .echo-outline-list {
@@ -284,31 +299,33 @@ body.outline-active .echo-header::before {
   width: 100%;
   background: linear-gradient(
     90deg,
-    hsla(var(--echo-tint, 180deg), 60%, 25%, 0.5) 0%,
-    rgba(0, 0, 0, 0.3) 100%
+    hsla(var(--echo-tint, 180deg), 60%, 20%, 0.7) 0%,
+    rgba(15, 20, 25, 0.8) 100%
   );
   border: none;
-  border-bottom: 1px solid hsla(var(--echo-tint, 180deg), 80%, 55%, 0.3);
-  color: hsla(var(--echo-tint, 180deg), 100%, 75%, 0.9);
+  border-bottom: 1px solid hsla(var(--echo-tint, 180deg), 80%, 55%, 0.4);
+  color: hsla(var(--echo-tint, 180deg), 100%, 85%, 1);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 800;
+  font-size: 12px;
+  font-weight: 700;
   letter-spacing: 1.5px;
-  padding: 6px 12px;
+  padding: 8px 14px;
   text-align: left;
   display: flex;
   align-items: center;
-  gap: 6px;
-  transition: background 0.2s ease;
+  gap: 8px;
+  transition: all 0.3s ease;
 }
 
 .echo-outline-toggle:hover {
   background: linear-gradient(
     90deg,
-    hsla(var(--echo-tint, 180deg), 60%, 35%, 0.6) 0%,
-    rgba(0, 0, 0, 0.2) 100%
+    hsla(var(--echo-tint, 180deg), 70%, 30%, 0.85) 0%,
+    rgba(20, 25, 30, 0.9) 100%
   );
+  color: #fff;
+  text-shadow: 0 0 8px hsla(var(--echo-tint, 180deg), 100%, 70%, 0.8);
 }
 
 .echo-symbol-outline[data-collapsed="true"] .echo-outline-toggle {
@@ -348,23 +365,27 @@ body.outline-active .echo-header::before {
 }
 
 .echo-outline-item {
+  padding: 6px 12px;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 3px 12px;
+  gap: 8px;
   font-family: var(--font-mono);
   font-size: 11px;
-  color: rgba(200, 230, 255, 0.75);
-  cursor: default;
-  transition: background 0.15s ease;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-left: 2px solid transparent;
+  color: hsla(var(--echo-tint, 180deg), 70%, 75%, 0.8);
+  background: rgba(0, 0, 0, 0.2);
+  margin-bottom: 2px;
+  border-radius: 4px;
 }
 
 .echo-outline-item:hover {
-  background: hsla(var(--echo-tint, 180deg), 100%, 60%, 0.08);
-  color: rgba(220, 245, 255, 0.95);
+  background: rgba(0, 229, 255, 0.15);
+  border-left: 2px solid hsla(var(--echo-tint, 180deg), 100%, 65%, 1);
+  color: hsla(var(--echo-tint, 180deg), 100%, 95%, 1);
+  transform: translateX(4px);
+  box-shadow: inset 0 0 10px rgba(0, 229, 255, 0.1);
 }
 
 .outline-kind-icon {

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -1026,20 +1026,24 @@ body.stack-deck-active .echo-document {
 }
 
 body.stack-deck-active .echo-document {
-  background: rgba(10, 15, 25, 0.8) !important;
-  backdrop-filter: blur(8px) !important;
-  -webkit-backdrop-filter: blur(8px) !important;
-  border: 1px solid rgba(255, 255, 255, 0.2) !important;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.6), inset 0 2px 5px rgba(255, 255, 255, 0.1) !important;
+  background: linear-gradient(135deg, rgba(20, 25, 40, 0.85) 0%, rgba(5, 10, 20, 0.95) 100%) !important;
+  backdrop-filter: blur(12px) saturate(150%) !important;
+  -webkit-backdrop-filter: blur(12px) saturate(150%) !important;
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  border-top: 1px solid rgba(255, 255, 255, 0.3) !important;
+  border-left: 1px solid rgba(255, 255, 255, 0.2) !important;
+  border-radius: 12px !important;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.7), inset 0 2px 10px rgba(255, 255, 255, 0.05) !important;
 }
 
 body.stack-deck-active .echo-document:hover {
-  border-color: rgba(0, 229, 255, 0.8) !important;
-  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.8), 0 0 20px rgba(0, 229, 255, 0.4), inset 0 2px 10px rgba(255, 255, 255, 0.2) !important;
-  transform: translate3d(calc(var(--tx, 0) - 15px), calc(var(--ty, 0) - 15px), calc(var(--tz, 0) + 20px)) scale(1.02) !important;
+  border-color: rgba(0, 229, 255, 0.9) !important;
+  border-top: 1px solid rgba(0, 255, 255, 1) !important;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.9), 0 0 30px rgba(0, 229, 255, 0.3), inset 0 2px 15px rgba(255, 255, 255, 0.3) !important;
+  transform: translate3d(calc(var(--tx, 0) - 20px), calc(var(--ty, 0) - 20px), calc(var(--tz, 0) + 40px)) scale(1.05) rotateX(5deg) rotateY(-5deg) !important;
   z-index: 1000 !important;
   opacity: 1 !important;
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s, box-shadow 0.3s !important;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.4s, border-color 0.4s !important;
 }
 
 /* Innovate: Focus Pull Interaction (Alt + F) */


### PR DESCRIPTION
This PR drastically improves the layout rendering and visual depth of the Web IDE's internal layering engine for the `Stack Deck View` and `Outline View`.

**Stack Deck Changes:**
- Migrated basic opacity/borders to `backdrop-filter: blur(12px) saturate(150%)`.
- Replaced flat hover translations with multi-axis `rotateX`, `rotateY`, scaling, and vibrant cyan box-shadows.

**Outline Changes:**
- Enhanced `.outline-active` `echo-document` shells with a glowing scale effect and `backdrop-filter`.
- Redesigned the `.echo-symbol-outline` inner panel using dynamic `max-height` transitions, a glassmorphic frame, and modern gradients for headers.
- Hovered outline-list elements now slide with `translateX`, highlight via nested background colors, and use custom easing.

---
*PR created automatically by Jules for task [12757968397135583811](https://jules.google.com/task/12757968397135583811) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced outline-mode visuals with stronger active states, clearer document panels, and more prominent hover effects.
  - Refined outline controls and items with updated spacing, colors, transitions, and interactive feedback.
  - Improved Stack Deck View appearance with refreshed gradients, borders, shadows, blur effects, and hover animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->