### PR TITLE
Set up Cursor Cloud dev environment + fix build-breaking syntax errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,3 +210,13 @@ Opening a file from the 3D cabinet pushes existing tabs to depth 1 and pulls the
 
 - The `Kimi_Agent/` directory contains patches and alternate file versions. It is **not part of the main build** and should not be edited unless you are specifically working on agent-side patches.
 - If you change any of the above architectural patterns (build tool, module wiring, backend base URL handling, or depth/view-mode systems), update this file to keep it accurate.
+
+---
+
+## Cursor Cloud specific instructions
+
+- **Runtime**: Node 22 (`package.json` requires `>=22.0.0`). Dependencies install with plain `npm install`; the startup update script already runs this, so you normally do not need to reinstall.
+- **Run the app (dev)**: `npm run dev` (Vite dev server, default port `5173`). Standard commands live in the `Build & Dev Commands` section above and in `package.json` — don't duplicate them. `dev.log` in the repo shows a past run using `--host 0.0.0.0 --port 3000`; that host/port is arbitrary, the app works on the default `5173`.
+- **Lint/tests**: none exist (no linter config, no test framework/tests). See the `Testing` section above. "Passing lint/tests" is not applicable in this repo.
+- **`src/` is split into many hand-maintained fragment files** (`main_*.js`, `TabManager_*.js`, `Cabinet3D_*.js`, `styles_*.css`, etc.). Vite fails hard on any single syntax error in these: `npm run dev` shows a blank page with a `Failed to scan for dependencies` / `Pre-transform error` in the Vite terminal, and `npm run build` aborts with `invalid JS syntax`. If the app renders blank, first check the Vite terminal (or run `node_modules/.bin/esbuild <file> --outfile=/dev/null` on suspect files) to locate the offending fragment before debugging anything else.
+- **Backend**: `StorageAPI.js` calls the remote FastAPI backend at `https://storage.noahcohn.com` (override with `VITE_STORAGE_BASE_URL`). There is no local backend to run — File Cabinet / VPS Files features depend on that remote host being reachable. The editor, rain effects, tabs, and view modes all work fully offline without it.

--- a/src/main_init_4.js
+++ b/src/main_init_4.js
@@ -1002,6 +1002,7 @@ document.addEventListener("keydown", (e) => {
     e.preventDefault();
     if (!document.body.classList.contains("magnifier-active")) {
       document.body.classList.add("magnifier-active");
+    }
     if (e.shiftKey) {
       if (!document.body.classList.contains("magnetic-sep-active")) {
         document.body.classList.add("magnetic-sep-active");
@@ -1017,6 +1018,7 @@ document.addEventListener("keydown", (e) => {
 document.addEventListener("keyup", (e) => {
   if (e.key === "m" || e.key === "M" || e.key === "Alt") {
     document.body.classList.remove("magnifier-active");
+  }
   if (e.key === "m" || e.key === "M" || e.key === "Alt" || e.key === "Shift") {
     document.body.classList.remove("obscured-magnifier-active");
     document.body.classList.remove("magnetic-sep-active");

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -1256,6 +1256,8 @@ body.magnifier-active #editor {
 
 body.magnifier-active #magnifier-lens {
   opacity: 1;
+}
+
 /* X-Ray Lens - More robust & performant */
 @layer ui-modes {
   body.xray-lens-active {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for **rain-2** (Vite + Monaco vanilla-JS SPA) for Cursor Cloud agents, documents non-obvious run caveats, and fixes the pre-existing syntax errors that broke `npm run build` and `npm run dev`.

## What was done

- Verified toolchain: Node `v22.14.0`, npm `10.9.7` (repo requires Node `>=22`).
- Installed dependencies with `npm install` (set as the startup update script).
- Fixed build-breaking syntax errors (see below), then confirmed `npm run build` succeeds (`✓ 1010 modules transformed`) and `npm run dev` (port `5173`) serves the app; the Monaco editor renders and accepts input.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering run commands, the lack of lint/test tooling, the split-fragment source-layout gotcha, and the remote backend dependency.

## Syntax fixes

- `src/main_init_4.js` — added the missing `}` that closed the `if (!magnifier-active)` block in the `keydown` handler, and the missing `}` closing the first `if` in the `keyup` handler. Without these, Rollup/esbuild hit `Unexpected ")"` and the whole `main.js` module graph failed to parse.
- `src/styles_14.css` — added the missing `}` closing the `body.magnifier-active #magnifier-lens` rule (PostCSS `unclosed block`).

## Known remaining (non-fatal) runtime issues — not addressed here

After load, the console still shows some pre-existing runtime errors (e.g. `connectionManager.setEditorFocus is not a function`, `window.tabManager.setFileDepth`/`setHovered is not a function`). These do not block the editor/build and are out of scope for this environment-setup PR.

## Environment role split

- **Update script** (runs on VM startup): `npm install`.
- **AGENTS.md**: durable run/build caveats for future agents.

## Demo (after fix)

App loaded:

![rain-2 app loaded after fix](https://cursor.com/artifacts/c/art-d7ae4296-31bf-4f0f-b8fe-3ac99657cc11)

`BUILD_FIXED.JS` code visible in the Monaco editor:

![code visible in editor after fix](https://cursor.com/artifacts/c/art-7204353e-a5a5-4fd0-862f-6d9e2e75712f)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9737795b-f203-4a03-a8dd-61c26a04dc1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9737795b-f203-4a03-a8dd-61c26a04dc1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

