### PR TITLE
Add Stack Deck view mode

### DIFF
--- a/src/TabManager_0.js
+++ b/src/TabManager_0.js
@@ -200,6 +200,15 @@ export const TabManagerMixin0 = {
     }
     this._renderEchoes();
   },
+  toggleStackDeckView() {
+    const wasActive = this.isStackDeckView;
+    this._deactivateAllViews();
+    if (!wasActive) {
+      this.isStackDeckView = true;
+      document.body.classList.add("stack-deck-active");
+    }
+    this._renderEchoes();
+  },
   toggleFibonacciSpiralView() {
     const wasActive = this.isFibonacciSpiralView;
     this._deactivateAllViews();

--- a/src/TabManager_3.js
+++ b/src/TabManager_3.js
@@ -851,6 +851,19 @@ export const TabManagerMixin3 = {
     return false;
   },
   _applyLayoutChunk4(el, index, totalEchoes, file, inactiveFiles, activeFile) {
+      if (this.isStackDeckView) {
+        // Stack Deck View positions
+        const spacingY = 40;
+        const spacingZ = 15;
+
+        el.style.setProperty("--tx", `0px`);
+        el.style.setProperty("--ty", `${index * spacingY}px`);
+        el.style.setProperty("--tz", `${-index * spacingZ}px`);
+        el.style.setProperty("--rot-x", "0deg");
+        el.style.setProperty("--rot-y", "0deg");
+        el.style.setProperty("--rot-z", "0deg");
+        return true;
+      }
       if (this.isScatteredView) {
         // Scattered View positions
         let _totalEchoes = inactiveFiles.length;

--- a/src/main_init_2.js
+++ b/src/main_init_2.js
@@ -172,6 +172,7 @@ if (viewModeSelect) {
     else if (view === "hexagon-matrix") tabManager.toggleHexagonMatrixView();
     else if (view === "luminescence") tabManager.toggleLuminescenceView();
     else if (view === "geode") tabManager.toggleGeodeView();
+    else if (view === "stackdeck") tabManager.toggleStackDeckView();
     else tabManager._deactivateAllViews(); // Default view
   });
 }

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -916,3 +916,27 @@ body.shattered-glass-active .echo-document:hover {
     50% { transform: scale(1.05) translateZ(calc(var(--tz) + 50px)); filter: brightness(1.5) drop-shadow(0 0 20px cyan); }
     100% { transform: scale(1) translateZ(var(--tz)); filter: brightness(1); }
 }
+/* Stack Deck View styles */
+body.stack-deck-active .echo-document {
+  transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1), opacity 0.5s ease;
+  transform: translate3d(var(--tx, 0), var(--ty, 0), var(--tz, 0))
+             rotateX(var(--rot-x, 0)) rotateY(var(--rot-y, 0)) rotateZ(var(--rot-z, 0));
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(10, 10, 15, 0.85);
+  backdrop-filter: blur(10px);
+}
+
+body.stack-deck-active .echo-document:hover {
+  transform: translate3d(var(--tx, 0), calc(var(--ty, 0) - 20px), calc(var(--tz, 0) + 10px))
+             rotateX(var(--rot-x, 0)) rotateY(var(--rot-y, 0)) rotateZ(var(--rot-z, 0));
+  box-shadow: 0 15px 40px rgba(0, 255, 200, 0.3);
+  border-color: rgba(0, 255, 200, 0.5);
+  z-index: 1000 !important;
+}
+
+body.stack-deck-active #editor {
+  z-index: 100;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(0, 255, 200, 0.3);
+}


### PR DESCRIPTION
Implemented a new "Stack Deck" view mode for the IDE. This mode stacks the background document layers vertically in a 3D space, similar to a deck of cards.

**Features:**
* Documents are visually stacked downwards and slightly backwards.
* Hovering a document smoothly pops it out forward.
* Styled with glassmorphism to fit the rest of the application.

**Testing:**
* Passed `npm run check`, `npm run typecheck`, and `npm test`.
* Passed `npm run build`.
* UI tested using Playwright and visually verified with screenshots.

---
*PR created automatically by Jules for task [2240591851803689343](https://jules.google.com/task/2240591851803689343) started by @ford442*