### PR TITLE
feat: add Prismatic Unfold lens and standardize glassmorphism UI

### DIFF
--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -29,6 +29,27 @@ export function registerLensBindings(manager, { doc = document } = {}) {
     onUp: () => body.classList.remove("magnifier-active", "magnetic-sep-active"),
   });
 
+
+  manager.register({
+    id: "prismatic-unfold",
+    category: "lens",
+    description: "Prismatic unfold / fan (Alt+Shift+U)",
+    combo: { alt: true, shift: true, code: "KeyU" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("prismatic-unfold-active");
+      // Set an item-index variable for each document so we can fan them out in CSS
+      const echoLayer = document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((doc, idx) => {
+          doc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("prismatic-unfold-active"),
+  });
+
   // Pointer tracking for the lens center (was MagnifierLens.handlePointerMove).
   if (typeof doc.addEventListener === "function") {
     doc.addEventListener("mousemove", (e) => {

--- a/src/styles_1.css
+++ b/src/styles_1.css
@@ -562,7 +562,7 @@ textarea:focus {
   height: auto;
   min-height: 64px;
   display: flex;
-  flex-direction: column;
+  flex-direction: row; flex-wrap: wrap; justify-content: center; align-items: center;
   gap: 14px;
   padding: 22px 28px;
   overflow: hidden;
@@ -573,32 +573,24 @@ textarea:focus {
     rgba(30, 35, 50, 0.65),
     rgba(10, 15, 25, 0.75)
   );
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.15'/%3E%3C/svg%3E");
-  background-blend-mode: overlay;
-  backdrop-filter: blur(50px) saturate(220%);
-  -webkit-backdrop-filter: blur(50px) saturate(220%);
+  backdrop-filter: blur(20px) saturate(150%);
+  -webkit-backdrop-filter: blur(20px) saturate(150%);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-top: 1px solid rgba(255, 255, 255, 0.3);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.6);
-  border-radius: 28px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
   box-shadow:
-    0 25px 50px rgba(0, 0, 0, 0.85),
-    inset 0 2px 0 rgba(255, 255, 255, 0.4),
-    inset 0 0 10px rgba(255, 255, 255, 0.1),
-    0 0 40px rgba(0, 229, 255, 0.2);
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    0 20px 40px rgba(0, 0, 0, 0.5),
+    0 0 75px rgba(0, 229, 255, 0.1),
+    inset 0 1px 2px rgba(255, 255, 255, 0.15);
+  z-index: 10000;
+  transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1), box-shadow 0.4s ease;
+}
 
-  z-index: 20;
-  color: var(--text-primary);
-  font-size: 11px;
-  transform: perspective(1000px) rotateX(var(--rx, 0deg))
-    rotateY(var(--ry, 0deg));
-  user-select: none;
-  transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-  transform-origin: bottom right;
-  opacity: 0.9;
-  max-width: 64px;
-  max-height: 64px;
+#dock:hover {
+  box-shadow:
+    0 25px 50px rgba(0, 0, 0, 0.6),
+    0 0 90px rgba(0, 229, 255, 0.2),
+    inset 0 1px 3px rgba(255, 255, 255, 0.25);
 }
 
 #dock::before {
@@ -628,9 +620,7 @@ textarea:focus {
     inset 0 0 20px rgba(0, 229, 255, 0.1);
 }
 
-#dock {
-  transition: transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1), box-shadow 0.4s ease;
-}
+
 
 #dock::after {
   content: "";
@@ -653,22 +643,7 @@ textarea:focus {
 
 
 /* Override dock for better UI */
-#dock {
-  display: flex !important;
-  flex-direction: row !important;
-  flex-wrap: wrap !important;
-  gap: 16px !important;
-  justify-content: center !important;
-  align-items: center !important;
-  padding: 16px 24px !important;
-  border-radius: 16px !important;
-  bottom: 24px !important;
-  width: auto !important;
-  max-width: 90vw !important;
-  background: transparent !important;
-  box-shadow: none !important;
-  border: none !important;
-}
+
 
 .dock-title {
   width: 100% !important;

--- a/src/styles_10.css
+++ b/src/styles_10.css
@@ -39,27 +39,7 @@
   color: inherit !important; /* Retain standard syntax color on hover, or keep glow based on design */
 }
 
-#dock {
-  position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  gap: 15px;
-  padding: 12px 24px;
-  background: rgba(15, 20, 25, 0.7);
-  backdrop-filter: blur(20px) saturate(150%);
-  -webkit-backdrop-filter: blur(20px) saturate(150%);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
-  box-shadow:
-    0 20px 40px rgba(0, 0, 0, 0.5),
-    inset 0 1px 2px rgba(255, 255, 255, 0.1);
-  z-index: 10000;
-}
+
 #tabs-container {
   transition:
     transform 0.2s ease-out,
@@ -285,7 +265,6 @@ body.origami-active .echo-document:hover {
 }
 
 /* Glassmorphism UI */
-#dock,
 #tabs-container {
   background: linear-gradient(135deg, rgba(25, 30, 45, 0.85), rgba(15, 20, 30, 0.95));
   backdrop-filter: blur(80px) saturate(250%);
@@ -301,7 +280,6 @@ body.origami-active .echo-document:hover {
   transition: all 0.3s ease-in-out;
 }
 
-#dock:hover,
 #tabs-container:hover {
   background: linear-gradient(135deg, rgba(35, 40, 55, 0.9), rgba(25, 30, 40, 0.98));
   box-shadow:
@@ -498,7 +476,6 @@ body.data-hive-active .echo-document:hover {
 }
 
 /* Glassmorphism UI (Overrides) */
-#dock,
 #tabs-container {
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01)) !important;
   backdrop-filter: blur(24px) saturate(160%) !important;

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -281,15 +281,7 @@ body.fanning-active .echo-document:hover {
     url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.08'/%3E%3C/svg%3E") !important;
 }
 
-#dock {
-  box-shadow:
-    0 25px 70px rgba(0, 0, 0, 0.8),
-    inset 0 1px 2px rgba(255, 255, 255, 0.2),
-    inset 0 -1px 5px rgba(0, 0, 0, 0.5),
-    inset calc(cos(var(--highlight-angle, 0deg)) * 10px)
-      calc(sin(var(--highlight-angle, 0deg)) * 10px) 20px
-      rgba(0, 229, 255, 0.05) !important;
-}
+
 
 #tabs-container {
   display: flex;
@@ -645,17 +637,7 @@ body.pulse-wave-active .echo-document {
   border-radius: 40px !important;
 }
 
-#dock {
-  background: linear-gradient(135deg, rgba(20, 25, 35, 0.85), rgba(10, 15, 20, 0.95)) !important;
-  backdrop-filter: blur(60px) saturate(200%) !important;
-  -webkit-backdrop-filter: blur(60px) saturate(200%) !important;
-  border: 1px solid rgba(0, 229, 255, 0.25) !important;
-  box-shadow:
-    0 40px 100px rgba(0, 0, 0, 0.9),
-    0 0 60px rgba(0, 229, 255, 0.15),
-    inset 0 2px 5px rgba(255, 255, 255, 0.1) !important;
-  border-radius: 24px !important;
-}
+
 
 /* 2. Editor Aurora Border Spin */
 #editor {
@@ -939,4 +921,28 @@ body.stack-deck-active #editor {
   z-index: 100;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
   border: 1px solid rgba(0, 255, 200, 0.3);
+}
+
+/* Prismatic Unfold Lens (Alt+Shift+U) */
+body.prismatic-unfold-active .echo-document {
+  transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), filter 0.4s ease, opacity 0.4s ease !important;
+  transform: translate3d(
+    calc(var(--tx, 0px) + ((var(--item-index, 0) - 1) * 80px)),
+    var(--ty, 0px),
+    calc(var(--tz, 0px) + 200px - (var(--item-index, 0) * 20px))
+  ) rotateY(calc((var(--item-index, 0) - 1) * -5deg)) scale(0.95) !important;
+  opacity: 0.9 !important;
+  filter: blur(0px) brightness(1.2) drop-shadow(0 15px 30px rgba(0, 229, 255, 0.4)) !important;
+  z-index: calc(100 - var(--item-index, 0)) !important;
+}
+
+body.prismatic-unfold-active .echo-document:hover {
+  transform: translate3d(
+    calc(var(--tx, 0px) + ((var(--item-index, 0) - 1) * 80px)),
+    calc(var(--ty, 0px) - 20px),
+    calc(var(--tz, 0px) + 250px)
+  ) scale(1.05) !important;
+  z-index: 200 !important;
+  opacity: 1 !important;
+  filter: brightness(1.4) drop-shadow(0 20px 40px rgba(0, 229, 255, 0.6)) !important;
 }

--- a/src/styles_4.css
+++ b/src/styles_4.css
@@ -334,7 +334,10 @@ body.x-ray-active #echo-layer {
   ); /* Slightly larger base font size for legibility */
   line-height: 1.6;
   color: #d8f5ff; /* Slightly brighter text color */
-  opacity: 0.15; /* Slightly higher base opacity */
+  opacity: 0.15;
+  background: rgba(15, 25, 35, 0.55);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%); /* Slightly higher base opacity */
   filter: blur(4px) hue-rotate(var(--echo-tint, 0deg));
 
   /* Scroll-Linked Kinetic Chromatic Aberration */
@@ -612,12 +615,9 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
 .echo-document {
   /* Enhanced glowing edge and deepened shadow */
   box-shadow:
-    0 100px 200px rgba(0, 0, 0, 0.98),
     0 40px 80px rgba(0, 0, 0, 0.6),
-    inset 0 2px 5px rgba(255, 255, 255, 0.7),
-    inset 0 0 150px hsla(var(--echo-tint, 0deg), 100%, 60%, 0.25),
-    inset 0 0 45px rgba(255, 255, 255, 0.15),
-    0 0 75px hsla(var(--echo-tint, 0deg), 100%, 60%, 0.5),
+    inset 0 2px 5px rgba(255, 255, 255, 0.2),
+    inset 0 0 15px hsla(var(--echo-tint, 0deg), 100%, 60%, 0.1),
     0 0 15px rgba(0, 229, 255, 0.1); /* Subtle outer glow to emphasize edges */
 
   /* Glitch animation property for distant echo documents */


### PR DESCRIPTION
Implemented the user's request to "Improve the formatting and look and feel of this web IDE" and "Improvise and innovate new features that take advantage of the layers of partially obscured documents."

### Look and Feel Polish
1. Cleaned up multiple conflicting CSS blocks across shards for the main `#dock`. Established a single, definitive glassmorphism treatment with flex-row layout in `src/styles_1.css`.
2. Standardized the `.echo-document` cards in `src/styles_4.css`. Applied a consistent `rgba(15, 25, 35, 0.55)` background and `backdrop-filter: blur(12px) saturate(140%)` for a unified glass material feel regardless of the view mode.

### Feature Innovation: Prismatic Unfold
Registered a new lens interaction through `InputManager` in `src/interactions/lensBindings.js`. Holding `Alt+Shift+U` applies `.prismatic-unfold-active`, updating an `--item-index` CSS variable for every echo document. This is tied to new rules in `styles_14.css` which temporarily fans the obscured layers across the Z and X axis, allowing the user to scan the depth stack without changing their permanent view configuration. 

Smoke tests (Playwright) and unit tests pass. Video and screenshot verification confirmed the aesthetic updates and the interaction.

---
*PR created automatically by Jules for task [6245373195880428011](https://jules.google.com/task/6245373195880428011) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Prismatic Unfold shortcut (Alt+Shift+U) to arrange documents with a dynamic 3D visual effect.
  - Hovering over a document in this mode highlights and enlarges it for easier focus.

- **Style**
  - Refined document transparency, blur, shadows, and visual layering.
  - Updated dock layout and appearance for a cleaner, more flexible interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->