### PR TITLE
feat: enhance UI formatting and add Chrono-Ghost/Kaleidoscope lenses

### DIFF
--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -51,6 +51,36 @@ export function registerLensBindings(manager, { doc = document } = {}) {
     onUp: () => body.classList.remove("magnifier-active", "magnetic-sep-active"),
   });
 
+  manager.register({
+    id: "chrono-ghost",
+    category: "lens",
+    description: "Chrono-Ghost Wireframe Lens (Alt+F)",
+    combo: { alt: true, code: "KeyF" },
+    type: "hold",
+    group: "lens",
+    onDown: () => body.classList.add("magnifier-active", "chrono-ghost-active"),
+    onUp: () => body.classList.remove("magnifier-active", "chrono-ghost-active"),
+  });
+
+  manager.register({
+    id: "kaleidoscope-split",
+    category: "lens",
+    description: "Kaleidoscope Split Lens (Alt+Shift+K)",
+    combo: { alt: true, shift: true, code: "KeyK" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("magnifier-active", "kaleidoscope-active");
+      const echoLayer = document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((doc, idx) => {
+          doc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("magnifier-active", "kaleidoscope-active"),
+  });
+
 
   manager.register({
     id: "prismatic-unfold",

--- a/src/styles_1.css
+++ b/src/styles_1.css
@@ -72,10 +72,11 @@ body,
   bottom: 0;
   z-index: 5; /* default: depth 1 — middle between rain layers; JS will update dynamically */
   box-shadow:
-    0 20px 60px rgba(0, 0, 0, 0.9),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
+    0 40px 80px rgba(0, 0, 0, 0.8),
+    inset 0 2px 10px rgba(255, 255, 255, 0.15),
+    0 0 20px rgba(0, 229, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
 
   /* Cyber Grid Background */
   background-image:

--- a/src/styles_11.css
+++ b/src/styles_11.css
@@ -190,33 +190,36 @@ body.solar-system-active #echo-layer::before {
 /* Optional: A sleek title bar for the active editor */
 .editor-title-bar {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
   height: 32px;
+  width: auto;
+  min-width: 200px;
+  justify-content: center;
   background: linear-gradient(
     135deg,
-    rgba(25, 30, 45, 0.75) 0%,
-    rgba(10, 15, 25, 0.65) 100%
+    rgba(25, 30, 45, 0.85) 0%,
+    rgba(10, 15, 25, 0.75) 100%
   );
-  backdrop-filter: blur(24px) saturate(150%);
-  -webkit-backdrop-filter: blur(24px) saturate(150%);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-  border-top: 1px solid rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(32px) saturate(200%);
+  -webkit-backdrop-filter: blur(32px) saturate(200%);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 16px;
   box-shadow:
-    0 15px 45px rgba(0, 0, 0, 0.85),
-    inset 0 1px 2px rgba(255, 255, 255, 0.4),
-    0 0 15px rgba(0, 229, 255, 0.2);
+    0 15px 45px rgba(0, 0, 0, 0.9),
+    inset 0 1px 2px rgba(255, 255, 255, 0.5),
+    0 0 25px rgba(0, 229, 255, 0.3);
   color: #00e5ff;
   font-size: 13px;
   font-weight: 600;
   display: flex;
   align-items: center;
-  padding-left: 20px;
+  padding: 0 24px;
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 2.5px;
-  text-shadow: 0 0 10px rgba(0, 229, 255, 0.9);
+  text-shadow: 0 0 12px rgba(0, 229, 255, 1);
   z-index: 10;
   transition: all 0.3s ease-in-out;
 }
@@ -224,14 +227,14 @@ body.solar-system-active #echo-layer::before {
 .editor-title-bar:hover {
   background: linear-gradient(
     135deg,
-    rgba(35, 45, 60, 0.8) 0%,
-    rgba(15, 25, 35, 0.7) 100%
+    rgba(35, 45, 60, 0.9) 0%,
+    rgba(15, 25, 35, 0.8) 100%
   );
   box-shadow:
-    0 18px 50px rgba(0, 0, 0, 0.9),
-    inset 0 1px 3px rgba(255, 255, 255, 0.5),
-    0 0 25px rgba(0, 229, 255, 0.4);
-  text-shadow: 0 0 15px rgba(0, 229, 255, 1);
+    0 18px 50px rgba(0, 0, 0, 0.95),
+    inset 0 1px 3px rgba(255, 255, 255, 0.6),
+    0 0 30px rgba(0, 229, 255, 0.5);
+  transform: translateX(-50%) translateY(-2px);
 }
 
 /* --- Echo Hover Lift (Innovation) --- */

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -1031,3 +1031,91 @@ body.xray-core-active #editor::before {
   z-index: 100;
   mix-blend-mode: screen;
 }
+
+/* ─── Chrono-Ghost Wireframe Lens (Alt+F) ───────────────────────────────── */
+body.chrono-ghost-active .echo-document {
+  transition: opacity 0.3s ease, filter 0.3s ease, transform 0.4s ease, border-color 0.3s ease;
+  background-color: transparent !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  border: 2px solid rgba(0, 229, 255, 0.4) !important;
+  box-shadow:
+    0 0 15px rgba(0, 229, 255, 0.2),
+    inset 0 0 15px rgba(0, 229, 255, 0.2) !important;
+  color: rgba(255, 255, 255, 0.8) !important;
+  opacity: 0.8 !important;
+}
+
+body.chrono-ghost-active .echo-document::before {
+  display: none !important;
+}
+
+body.chrono-ghost-active #editor {
+  mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+  transition: opacity 0.3s ease;
+}
+
+body.chrono-ghost-active #editor::before {
+  content: "";
+  position: absolute;
+  inset: -100%;
+  background: radial-gradient(
+    circle 250px at var(--mouse-local-x, 50%) var(--mouse-local-y, 50%),
+    rgba(0, 229, 255, 0.2) 0%,
+    transparent 100%
+  );
+  pointer-events: none;
+  z-index: 100;
+  mix-blend-mode: screen;
+}
+
+/* ─── Kaleidoscope Split Lens (Alt+Shift+K) ─────────────────────────────── */
+body.kaleidoscope-active #editor {
+  mask-image: radial-gradient(
+    circle 350px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 350px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+  transition: opacity 0.3s ease;
+}
+
+body.kaleidoscope-active .echo-document {
+  transition: clip-path 0.3s ease, filter 0.3s ease, transform 0.4s ease;
+  opacity: 0.9 !important;
+  filter: hue-rotate(calc(var(--item-index, 0) * 45deg)) drop-shadow(0 0 10px rgba(255,255,255,0.2)) !important;
+  z-index: 300 !important;
+}
+
+/* Quadrant 1 (Top-Left) */
+body.kaleidoscope-active .echo-document:nth-child(4n+1) {
+  clip-path: polygon(0 0, var(--lens-x, 50%) 0, var(--lens-x, 50%) var(--lens-y, 50%), 0 var(--lens-y, 50%));
+}
+
+/* Quadrant 2 (Top-Right) */
+body.kaleidoscope-active .echo-document:nth-child(4n+2) {
+  clip-path: polygon(var(--lens-x, 50%) 0, 100% 0, 100% var(--lens-y, 50%), var(--lens-x, 50%) var(--lens-y, 50%));
+}
+
+/* Quadrant 3 (Bottom-Left) */
+body.kaleidoscope-active .echo-document:nth-child(4n+3) {
+  clip-path: polygon(0 var(--lens-y, 50%), var(--lens-x, 50%) var(--lens-y, 50%), var(--lens-x, 50%) 100%, 0 100%);
+}
+
+/* Quadrant 4 (Bottom-Right) */
+body.kaleidoscope-active .echo-document:nth-child(4n+4) {
+  clip-path: polygon(var(--lens-x, 50%) var(--lens-y, 50%), 100% var(--lens-y, 50%), 100% 100%, var(--lens-x, 50%) 100%);
+}


### PR DESCRIPTION
This PR improves the overall look and feel of the Web IDE by applying a more modern aesthetic to the main editor and title bar (floating pill design, enhanced shadows, unified border radii).

It also introduces two innovative features utilizing the layers of partially obscured documents, leaning into the agent's instructions to add interactive lenses over permanent views:
1.  **Chrono-Ghost Wireframe Lens (Alt+F):** Renders hidden background tabs as wireframe outlines for quick, x-ray-like surveying without fully exposing them.
2.  **Kaleidoscope Split Lens (Alt+Shift+K):** Fragments and slices the background layers into an angular, multi-directional array using advanced CSS `clip-path` rules.

All keyboard shortcuts are properly mapped to `InputManager` with mutually exclusive class toggling correctly handled. CSS is appropriately scoped in `styles_14.css`.

**Testing Performed:**
- Visually verified via Playwright scripts that layers receive correct CSS masks and properties.
- `npm run ci` passes completely (including lint, typecheck, smoke tests).
- All testing artifacts have been securely cleaned from the directory.

---
*PR created automatically by Jules for task [3625970997240853985](https://jules.google.com/task/3625970997240853985) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two lens viewing modes: Chrono-Ghost Wireframe Lens (`Alt+F`) and Kaleidoscope Split Lens (`Alt+Shift+K`).
  * Lens modes provide focused wireframe, glow, quadrant, and color-shift visual effects.
  * Added keyboard hold-to-activate behavior with automatic mutual exclusion.

* **Style**
  * Enhanced editor glow, borders, corner rounding, and title bar presentation.
  * Improved title bar hover effects, positioning, gradients, and visual depth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->