### PR TITLE
feat: improve IDE formatting and add Neon Pulse and Ethereal Glitch lenses

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,10 +1,10 @@
 
 > rain-2@0.1.0 dev
-> vite --host 0.0.0.0 --port 3000
+> vite
 
 [33mThe CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.[39m
 
-  VITE v5.4.21  ready in 422 ms
+  VITE v5.4.21  ready in 560 ms
 
-  ➜  Local:   http://localhost:3000/
-  ➜  Network: http://192.168.0.2:3000/
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose

--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -202,6 +202,28 @@ export function registerLensBindings(manager, { doc = document } = {}) {
     onUp: () => body.classList.remove("magnifier-active", "ripple-displacement-active"),
   });
 
+  manager.register({
+    id: "neon-pulse",
+    category: "lens",
+    description: "Neon Pulse Lens (Alt+Shift+N)",
+    combo: { alt: true, shift: true, code: "KeyN" },
+    type: "hold",
+    group: "lens",
+    onDown: () => body.classList.add("magnifier-active", "neon-pulse-active"),
+    onUp: () => body.classList.remove("magnifier-active", "neon-pulse-active"),
+  });
+
+  manager.register({
+    id: "ethereal-glitch",
+    category: "lens",
+    description: "Ethereal Glitch Lens (Alt+Shift+J)",
+    combo: { alt: true, shift: true, code: "KeyJ" },
+    type: "hold",
+    group: "lens",
+    onDown: () => body.classList.add("magnifier-active", "ethereal-glitch-active"),
+    onUp: () => body.classList.remove("magnifier-active", "ethereal-glitch-active"),
+  });
+
   // Pointer tracking for the lens center (was MagnifierLens.handlePointerMove).
   if (typeof doc.addEventListener === "function") {
     doc.addEventListener("mousemove", (e) => {

--- a/src/styles_1.css
+++ b/src/styles_1.css
@@ -569,16 +569,12 @@ textarea:focus {
   overflow: hidden;
 
   /* Premium Glassmorphism */
-  background: linear-gradient(
-    135deg,
-    rgba(30, 35, 50, 0.65),
-    rgba(10, 15, 25, 0.75)
-  );
-  backdrop-filter: blur(20px) saturate(150%);
-  -webkit-backdrop-filter: blur(20px) saturate(150%);
+  background: rgba(10, 15, 25, 0.45);
+  backdrop-filter: blur(24px) saturate(150%);
+  -webkit-backdrop-filter: blur(24px) saturate(150%);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-top: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 16px;
+  border-radius: 24px;
   box-shadow:
     0 20px 40px rgba(0, 0, 0, 0.5),
     0 0 75px rgba(0, 229, 255, 0.1),

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -1332,3 +1332,137 @@ body.ripple-displacement-active .echo-document {
   filter: hue-rotate(calc(var(--tx, 0px) * 0.1deg)) saturate(200%) brightness(1.2) !important;
   z-index: 250 !important;
 }
+
+/* ─── Neon Pulse Lens (Alt+Shift+N) ─────────────────────────────────────── */
+body.neon-pulse-active #editor {
+  mask-image: radial-gradient(
+    circle 350px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    rgba(0, 0, 0, 0.4) 40%,
+    black 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 350px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    rgba(0, 0, 0, 0.4) 40%,
+    black 100%
+  );
+  transition: mask-image 0.3s ease;
+}
+
+body.neon-pulse-active .echo-document {
+  opacity: 0.95 !important;
+  z-index: 250 !important;
+  animation: neon-pulse-anim 2s infinite alternate ease-in-out;
+  transform: translate3d(
+      calc(var(--tx, 0px) + var(--part-tx, 0px) + var(--repel-tx, 0px) + var(--repulse-tx, 0px)),
+      calc(var(--ty, 0px) + var(--part-ty, 0px) + var(--repel-ty, 0px) + var(--repulse-ty, 0px)),
+      calc(var(--tz, 0px) + 200px)
+    )
+    rotateX(var(--rot-x, 0deg))
+    rotateY(var(--rot-y, 0deg))
+    rotateZ(var(--rot-z, 0deg)) scale(1.1) !important;
+}
+
+@keyframes neon-pulse-anim {
+  0% {
+    filter: hue-rotate(0deg) brightness(1.2) saturate(150%);
+    box-shadow: 0 0 20px rgba(0, 229, 255, 0.6), inset 0 0 10px rgba(0, 229, 255, 0.4) !important;
+    border-color: rgba(0, 229, 255, 0.8) !important;
+  }
+  100% {
+    filter: hue-rotate(90deg) brightness(1.5) saturate(200%);
+    box-shadow: 0 0 50px rgba(255, 0, 128, 0.8), inset 0 0 20px rgba(255, 0, 128, 0.6) !important;
+    border-color: rgba(255, 0, 128, 1) !important;
+  }
+}
+
+/* ─── Ethereal Glitch Lens (Alt+Shift+J) ────────────────────────────────── */
+body.ethereal-glitch-active #editor {
+  mask-image: repeating-linear-gradient(
+    0deg,
+    transparent 0px,
+    transparent 2px,
+    black 3px,
+    black 6px
+  );
+  -webkit-mask-image: repeating-linear-gradient(
+    0deg,
+    transparent 0px,
+    transparent 2px,
+    black 3px,
+    black 6px
+  );
+  transition: mask-image 0.3s ease;
+}
+
+body.ethereal-glitch-active .echo-document {
+  opacity: 0.9 !important;
+  z-index: 260 !important;
+  animation: glitch-slice 0.4s infinite linear alternate-reverse;
+  transform: translate3d(
+      calc(var(--tx, 0px) + var(--part-tx, 0px) + var(--repel-tx, 0px) + var(--repulse-tx, 0px)),
+      calc(var(--ty, 0px) + var(--part-ty, 0px) + var(--repel-ty, 0px) + var(--repulse-ty, 0px)),
+      calc(var(--tz, 0px) + 100px)
+    )
+    rotateX(var(--rot-x, 0deg))
+    rotateY(var(--rot-y, 0deg))
+    rotateZ(var(--rot-z, 0deg)) scale(1.05) !important;
+}
+
+@keyframes glitch-slice {
+  0% {
+    clip-path: polygon(0 0, 100% 0, 100% 10%, 0 10%);
+    filter: hue-rotate(0deg) contrast(1.5);
+    transform: translate3d(
+        calc(var(--tx, 0px) - 5px),
+        calc(var(--ty, 0px) + 2px),
+        calc(var(--tz, 0px) + 100px)
+      ) scale(1.05);
+  }
+  20% {
+    clip-path: polygon(0 15%, 100% 15%, 100% 30%, 0 30%);
+    filter: hue-rotate(90deg) contrast(2);
+    transform: translate3d(
+        calc(var(--tx, 0px) + 5px),
+        calc(var(--ty, 0px) - 2px),
+        calc(var(--tz, 0px) + 100px)
+      ) scale(1.05);
+  }
+  40% {
+    clip-path: polygon(0 35%, 100% 35%, 100% 50%, 0 50%);
+    filter: hue-rotate(180deg) contrast(1.5);
+    transform: translate3d(
+        calc(var(--tx, 0px) - 3px),
+        calc(var(--ty, 0px) + 4px),
+        calc(var(--tz, 0px) + 100px)
+      ) scale(1.05);
+  }
+  60% {
+    clip-path: polygon(0 55%, 100% 55%, 100% 70%, 0 70%);
+    filter: hue-rotate(270deg) contrast(2.5);
+    transform: translate3d(
+        calc(var(--tx, 0px) + 6px),
+        calc(var(--ty, 0px) - 5px),
+        calc(var(--tz, 0px) + 100px)
+      ) scale(1.05);
+  }
+  80% {
+    clip-path: polygon(0 75%, 100% 75%, 100% 90%, 0 90%);
+    filter: hue-rotate(360deg) contrast(1.5);
+    transform: translate3d(
+        calc(var(--tx, 0px) - 2px),
+        calc(var(--ty, 0px) + 2px),
+        calc(var(--tz, 0px) + 100px)
+      ) scale(1.05);
+  }
+  100% {
+    clip-path: polygon(0 95%, 100% 95%, 100% 100%, 0 100%);
+    filter: hue-rotate(90deg) contrast(3);
+    transform: translate3d(
+        calc(var(--tx, 0px) + 4px),
+        calc(var(--ty, 0px) - 3px),
+        calc(var(--tz, 0px) + 100px)
+      ) scale(1.05);
+  }
+}

--- a/src/styles_4.css
+++ b/src/styles_4.css
@@ -324,7 +324,7 @@ body.x-ray-active #echo-layer {
   left: 10%;
   width: 80%;
   height: 80%;
-  border-radius: 12px;
+  border-radius: 24px;
   pointer-events: auto; /* Allow hovering to peek */
   cursor: pointer;
   font-family: var(--font-mono);
@@ -335,9 +335,9 @@ body.x-ray-active #echo-layer {
   line-height: 1.6;
   color: #d8f5ff; /* Slightly brighter text color */
   opacity: 0.15;
-  background: rgba(15, 25, 35, 0.55);
-  backdrop-filter: blur(12px) saturate(140%);
-  -webkit-backdrop-filter: blur(12px) saturate(140%); /* Slightly higher base opacity */
+  background: rgba(10, 15, 25, 0.45);
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%); /* Slightly higher base opacity */
   filter: blur(4px) hue-rotate(var(--echo-tint, 0deg));
 
   /* Scroll-Linked Kinetic Chromatic Aberration */
@@ -615,7 +615,7 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
 .echo-document {
   /* Enhanced glowing edge and deepened shadow */
   box-shadow:
-    0 40px 80px rgba(0, 0, 0, 0.6),
+    0 45px 100px rgba(0, 0, 0, 0.8),
     inset 0 2px 5px rgba(255, 255, 255, 0.2),
     inset 0 0 15px hsla(var(--echo-tint, 0deg), 100%, 60%, 0.1),
     0 0 15px rgba(0, 229, 255, 0.1); /* Subtle outer glow to emphasize edges */
@@ -726,4 +726,9 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
 .depth-controls select option {
   background: #101520;
   color: #e0f0ff;
+}
+.echo-document:hover {
+  filter: brightness(1.3);
+  box-shadow: 0 0 25px rgba(0, 229, 255, 0.9), inset 0 0 15px rgba(0, 229, 255, 0.5) !important;
+  border-color: rgba(0, 229, 255, 1) !important;
 }


### PR DESCRIPTION
This PR improves the overall styling of the web IDE and adds two new visual features utilizing the partially obscured document layers.

**Updates:**
- Refined the primary `#dock` component with smoother glassmorphism: increased blur to 24px and softened background opacity.
- Modernized `.echo-document` background layers to match with 24px border radius and increased blur.
- Added an interactive `:hover` state on `.echo-document` layers, utilizing a bright cyan glow effect.
- Created **Neon Pulse Lens (Alt+Shift+N)**: Applies a dark radial mask and pulsates background layers with vivid alternating neon box shadows.
- Created **Ethereal Glitch Lens (Alt+Shift+J)**: Applies a repeating linear gradient mask over the editor while triggering rapid 3D translational shifts and geometric clip-path animations on the background layers.

All changes were successfully verified through Playwright interaction scripts (with generated screenshots & video for visual review) and passed the `npm run ci` local test suite.

---
*PR created automatically by Jules for task [1921859900311719262](https://jules.google.com/task/1921859900311719262) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Neon Pulse and Ethereal Glitch visual lenses, activated with keyboard shortcuts while held.
  * Introduced animated lens effects, including pulsing colors, scanlines, document distortion, and glitch transitions.

* **Style**
  * Refined the dock with a translucent background, stronger blur, and softer rounded corners.
  * Enhanced document panels with improved depth, hover brightness, cyan glow, and border highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->