### PR TITLE
feat: add Cosmic Void Lens interaction

### DIFF
--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -281,6 +281,26 @@ export function registerLensBindings(manager, { doc = document } = {}) {
     },
     onUp: () => body.classList.remove("magnifier-active", "ectoplasmic-ooze-active"),
   });
+
+  manager.register({
+    id: "cosmic-void",
+    category: "lens",
+    description: "Cosmic Void Lens (Alt+Shift+V)",
+    combo: { alt: true, shift: true, code: "KeyV" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("magnifier-active", "cosmic-void-active");
+      const echoLayer = doc.getElementById("echo-layer") || document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("magnifier-active", "cosmic-void-active"),
+  });
+
   if (typeof doc.addEventListener === "function") {
     doc.addEventListener("mousemove", (e) => {
       if (!body.classList.contains("magnifier-active")) return;

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -1547,3 +1547,48 @@ body.ectoplasmic-ooze-active .echo-document {
   border-bottom: 5px solid rgba(128, 255, 0, 0.8) !important;
   border-radius: 10px 10px 40% 40% !important;
 }
+
+/* Cosmic Void Lens (Alt+Shift+V) */
+body.cosmic-void-active #editor {
+  mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50vw) var(--lens-y, 50vh),
+    transparent 0%,
+    rgba(0, 0, 0, 0.4) 40%,
+    black 70%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50vw) var(--lens-y, 50vh),
+    transparent 0%,
+    rgba(0, 0, 0, 0.4) 40%,
+    black 70%
+  );
+}
+
+body.cosmic-void-active .echo-document {
+  transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1), filter 0.6s ease;
+  transform: translate3d(
+    calc(var(--tx, 0px) + (var(--item-index, 0) - 2) * 50px),
+    calc(var(--ty, 0px) + (var(--item-index, 0) - 2) * 30px),
+    calc(var(--tz, 0px) - (var(--item-index, 0) * 80px))
+  ) rotateZ(calc((var(--item-index, 0) - 2) * 20deg)) scale(calc(1 - (var(--item-index, 0) * 0.15))) !important;
+  filter: hue-rotate(calc(var(--item-index, 0) * 60deg)) saturate(400%) contrast(1.5) drop-shadow(0 0 40px rgba(138, 43, 226, 0.8)) drop-shadow(0 0 80px rgba(255, 0, 255, 0.6)) !important;
+  z-index: calc(100 - var(--item-index, 0)) !important;
+  border-radius: 50% !important;
+  opacity: 0.8 !important;
+}
+
+body.cosmic-void-active .echo-document::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, transparent 40%, rgba(255, 255, 255, 0.6) 80%, transparent 100%);
+  animation: cosmic-pulse 2s infinite ease-in-out alternate;
+  pointer-events: none;
+  z-index: -1;
+}
+
+@keyframes cosmic-pulse {
+  0% { transform: scale(0.9); opacity: 0.5; }
+  100% { transform: scale(1.2); opacity: 1; }
+}


### PR DESCRIPTION
This PR implements the "Cosmic Void Lens" (Alt+Shift+V) which adds a striking new visual effect taking advantage of the partially obscured document layers in the background. It registers the new interaction via `lensBindings.js`, and uses CSS masking, transforms, filters and animations based on layer index inside `styles_14.css`. Testing and smoke testing passed.

---
*PR created automatically by Jules for task [9285721102463885582](https://jules.google.com/task/9285721102463885582) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Cosmic Void Lens, activated with **Alt+Shift+V**.
  * Introduced a cursor-centered visual effect that refracts and layers editor documents.
  * Added animated cosmic pulse effects and enhanced circular styling for documents.
  * The lens activates while the shortcut is held and deactivates when released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->