### PR TITLE
feat: add Magma Core lens and enhance UI aesthetics

### DIFF
--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -264,6 +264,25 @@ export function registerLensBindings(manager, { doc = document } = {}) {
   });
 
   manager.register({
+    id: "magma-core",
+    category: "lens",
+    description: "Magma Core Lens (Alt+Shift+I)",
+    combo: { alt: true, shift: true, code: "KeyI" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("magnifier-active", "magma-core-active");
+      const echoLayer = doc.getElementById("echo-layer") || document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("magnifier-active", "magma-core-active"),
+  });
+
+  manager.register({
     id: "ectoplasmic-ooze",
     category: "lens",
     description: "Ectoplasmic Ooze Lens (Alt+Shift+Y)",

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -276,8 +276,8 @@ body.fanning-active .echo-document:hover {
       rgba(255, 255, 255, 0.02) !important;
   background-image:
     radial-gradient(rgba(0, 229, 255, 0.05) 1px, transparent 1px),
-    linear-gradient(rgba(0, 229, 255, 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0, 229, 255, 0.05) 1px, transparent 1px),
+    repeating-linear-gradient(rgba(0, 229, 255, 0.05) 0px, rgba(0, 229, 255, 0.05) 1px, transparent 1px, transparent 20px),
+    repeating-linear-gradient(90deg, rgba(0, 229, 255, 0.05) 0px, rgba(0, 229, 255, 0.05) 1px, transparent 1px, transparent 20px),
     url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.08'/%3E%3C/svg%3E") !important;
 }
 
@@ -1681,3 +1681,64 @@ body.quantum-fracture-active .echo-document:nth-child(4n+1) { clip-path: polygon
 body.quantum-fracture-active .echo-document:nth-child(4n+2) { clip-path: polygon(50% 0, 100% 0, 100% 100%, 0 50%); }
 body.quantum-fracture-active .echo-document:nth-child(4n+3) { clip-path: polygon(0 50%, 100% 0, 100% 100%, 50% 100%); }
 body.quantum-fracture-active .echo-document:nth-child(4n+4) { clip-path: polygon(0 0, 100% 50%, 50% 100%, 0 100%); }
+
+/* ─── Innovate: Magma Core Lens (Alt+Shift+I) ────────────────── */
+body.magma-core-active #editor {
+  mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50vw) var(--lens-y, 50vh),
+    transparent 0%,
+    rgba(0, 0, 0, 0.2) 20%,
+    rgba(0, 0, 0, 0.8) 50%,
+    black 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50vw) var(--lens-y, 50vh),
+    transparent 0%,
+    rgba(0, 0, 0, 0.2) 20%,
+    rgba(0, 0, 0, 0.8) 50%,
+    black 100%
+  );
+  transition: opacity 0.3s ease;
+}
+
+body.magma-core-active .echo-document {
+  transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1), filter 0.6s ease;
+  opacity: 0.9 !important;
+  z-index: calc(200 - var(--item-index, 0)) !important;
+  transform: translate3d(
+    calc(var(--tx, 0px) + var(--part-tx, 0px)),
+    calc(var(--ty, 0px) + var(--part-ty, 0px)),
+    calc(var(--tz, 0px) + 120px)
+  ) scale(1.1) !important;
+  mix-blend-mode: screen;
+  filter: hue-rotate(calc(300deg + (var(--item-index, 0) * 10deg))) saturate(400%) contrast(1.8) brightness(1.3) drop-shadow(0 0 25px rgba(255, 69, 0, 0.8)) !important;
+  border: 1px solid rgba(255, 69, 0, 0.5) !important;
+  animation: magma-haze 3s infinite alternate ease-in-out;
+}
+
+@keyframes magma-haze {
+  0% { transform: translate3d(
+    calc(var(--tx, 0px) + var(--part-tx, 0px)),
+    calc(var(--ty, 0px) + var(--part-ty, 0px)),
+    calc(var(--tz, 0px) + 120px)
+  ) scale(1.08) rotateZ(-1deg); }
+  100% { transform: translate3d(
+    calc(var(--tx, 0px) + var(--part-tx, 0px)),
+    calc(var(--ty, 0px) + var(--part-ty, 0px)),
+    calc(var(--tz, 0px) + 120px)
+  ) scale(1.12) rotateZ(1deg); }
+}
+
+body.magma-core-active .echo-document::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at var(--mouse-local-x, 50%) var(--mouse-local-y, 50%),
+    rgba(255, 140, 0, 0.5) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 10;
+  mix-blend-mode: overlay;
+}

--- a/src/styles_4.css
+++ b/src/styles_4.css
@@ -684,8 +684,7 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
     inset 0 1px 3px rgba(255, 255, 255, 0.4),
     inset 0 0 calc(80px + (var(--wake) * 50px))
       hsla(var(--echo-tint, 0deg), 100%, 60%, calc(0.15 + var(--wake) * 0.25)),
-    inset 0 0 15px
-      hsla(var(--echo-tint, 0deg), 100%, 80%, calc(0.1 + var(--wake) * 0.15)),
+    inset 0 0 15px hsla(var(--echo-tint, 0deg), 100%, 70%, 0.3),
     0 0 calc(35px + (var(--wake) * 25px))
       hsla(var(--echo-tint, 0deg), 100%, 60%, calc(0.2 + var(--wake) * 0.2));
 }
@@ -730,5 +729,5 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
 .echo-document:hover {
   filter: brightness(1.3);
   box-shadow: 0 0 25px rgba(0, 229, 255, 0.9), inset 0 0 15px rgba(0, 229, 255, 0.5) !important;
-  border-color: rgba(0, 229, 255, 1) !important;
+  border-color: rgba(255, 100, 200, 1) !important;
 }


### PR DESCRIPTION
This pull request improves the formatting and look-and-feel of the web IDE while introducing an innovative "Magma Core Lens" feature. 

Modifications:
1. **UI Refresh**: Enhanced `.echo-document` with stronger inset box-shadows and distinct hover colors in `src/styles_4.css`. Added a repeating-linear-gradient tech-grid visual structure to the background of the main editor.
2. **Magma Core Lens**: Registered a new lens named `magma-core` within `src/interactions/lensBindings.js` bound to `Alt+Shift+I`. This adds the `.magma-core-active` class.
3. **Immersive Layering Styles**: The lens applies a dynamic radial-gradient mask over the main editor to obscure the front layer while using `--item-index` and `hue-rotate` in `src/styles_14.css` to give background documents a staggered deep red/orange magma appearance. Includes a keyframe animation (`magma-haze`) for visual distortion.

Tested visually with a simulated playwright test script taking verification screenshots. Passed `npm run ci` without errors.

---
*PR created automatically by Jules for task [19769791865664803](https://jules.google.com/task/19769791865664803) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Magma Core Lens, activated with **Alt+Shift+I**.
  - Introduced animated magnifier effects, heat-based visuals, glowing highlights, and document transformations.

- **Style**
  - Updated the editor background grid and document glow effects.
  - Refined hover borders with a pink accent.
  - Added localized overlay highlighting for the active lens effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->