### PR TITLE
feat: Add Bioluminescent Trace and Digital Matrix Decode lenses

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -4,7 +4,7 @@
 
 [33mThe CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.[39m
 
-  VITE v5.4.21  ready in 560 ms
+  VITE v5.4.21  ready in 306 ms
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose

--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -358,6 +358,44 @@ export function registerLensBindings(manager, { doc = document } = {}) {
     onUp: () => body.classList.remove("magnifier-active", "cosmic-void-active"),
   });
 
+  manager.register({
+    id: "bioluminescent-trace",
+    category: "lens",
+    description: "Bioluminescent Trace Lens (Alt+Shift+T)",
+    combo: { alt: true, shift: true, code: "KeyT" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("magnifier-active", "bioluminescent-trace-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("magnifier-active", "bioluminescent-trace-active"),
+  });
+
+  manager.register({
+    id: "digital-matrix-decode",
+    category: "lens",
+    description: "Digital Matrix Decode Lens (Alt+Shift+O)",
+    combo: { alt: true, shift: true, code: "KeyO" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("magnifier-active", "digital-matrix-decode-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("magnifier-active", "digital-matrix-decode-active"),
+  });
+
   if (typeof doc.addEventListener === "function") {
     doc.addEventListener("mousemove", (e) => {
       if (!body.classList.contains("magnifier-active")) return;

--- a/src/styles_14.css
+++ b/src/styles_14.css
@@ -1742,3 +1742,115 @@ body.magma-core-active .echo-document::after {
   z-index: 10;
   mix-blend-mode: overlay;
 }
+
+/* Bioluminescent Trace Lens (Alt+Shift+B) */
+body.bioluminescent-trace-active #editor {
+  mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50vw) var(--lens-y, 50vh),
+    transparent 0%,
+    rgba(0, 0, 0, 0.4) 50%,
+    black 80%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50vw) var(--lens-y, 50vh),
+    transparent 0%,
+    rgba(0, 0, 0, 0.4) 50%,
+    black 80%
+  );
+}
+
+body.bioluminescent-trace-active .echo-document {
+  transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.2, 1), filter 0.5s ease;
+  transform: translate3d(
+    calc(var(--tx, 0px) + (var(--item-index, 0) - 2) * 20px),
+    calc(var(--ty, 0px) + (var(--item-index, 0) - 2) * 15px),
+    calc(var(--tz, 0px) + 80px - (var(--item-index, 0) * 10px))
+  ) scale(1.05) !important;
+  filter: hue-rotate(180deg) saturate(300%) brightness(1.2) contrast(1.8) drop-shadow(0 0 20px rgba(0, 255, 200, 0.8)) !important;
+  z-index: calc(100 - var(--item-index, 0)) !important;
+  opacity: 0.85 !important;
+  border: 1px solid rgba(0, 255, 200, 0.8) !important;
+  mix-blend-mode: screen;
+}
+
+body.bioluminescent-trace-active .echo-document::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+  border: 2px dashed rgba(0, 255, 200, 0.5);
+  border-radius: 12px;
+  animation: bioluminescent-pulse 2s infinite ease-in-out alternate;
+  pointer-events: none;
+  z-index: -1;
+}
+
+@keyframes bioluminescent-pulse {
+  0% { transform: scale(0.95); opacity: 0.3; }
+  100% { transform: scale(1.02); opacity: 1; box-shadow: inset 0 0 15px rgba(0, 255, 200, 0.4); }
+}
+
+
+/* Digital Matrix Decode Lens (Alt+Shift+M) */
+body.digital-matrix-decode-active #editor {
+  mask-image: linear-gradient(
+    to bottom,
+    black 0%,
+    transparent 30%,
+    transparent 70%,
+    black 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    black 0%,
+    transparent 30%,
+    transparent 70%,
+    black 100%
+  );
+  opacity: 0.5;
+}
+
+body.digital-matrix-decode-active .echo-document {
+  transition: transform 0.3s steps(5), clip-path 0.3s ease;
+  transform: translate3d(
+    calc(var(--tx, 0px) + (var(--item-index, 0) * 5px)),
+    calc(var(--ty, 0px) - (var(--item-index, 0) * 30px)),
+    calc(var(--tz, 0px) + 50px)
+  ) rotateX(calc(var(--item-index, 0) * 10deg)) !important;
+  filter: hue-rotate(90deg) saturate(200%) brightness(1.5) contrast(2) sepia(100%) drop-shadow(0 0 10px rgba(0, 255, 0, 0.8)) !important;
+  color: #0f0 !important;
+  background-color: rgba(0, 20, 0, 0.9) !important;
+  border: 1px solid rgba(0, 255, 0, 0.6) !important;
+  opacity: 0.9 !important;
+  z-index: calc(100 - var(--item-index, 0)) !important;
+}
+
+body.digital-matrix-decode-active .echo-document:nth-child(even) {
+  clip-path: polygon(10% 0%, 100% 0%, 90% 100%, 0% 100%);
+}
+body.digital-matrix-decode-active .echo-document:nth-child(odd) {
+  clip-path: polygon(0% 10%, 100% 0%, 100% 90%, 0% 100%);
+}
+
+body.digital-matrix-decode-active .echo-document::after {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: repeating-linear-gradient(
+      0deg,
+      rgba(0, 255, 0, 0.1) 0px,
+      rgba(0, 255, 0, 0.1) 2px,
+      transparent 2px,
+      transparent 4px
+    );
+    pointer-events: none;
+    z-index: 10;
+    animation: matrix-scanline 4s linear infinite;
+}
+
+@keyframes matrix-scanline {
+    from { transform: translateY(0); }
+    to { transform: translateY(100%); }
+}


### PR DESCRIPTION
This PR adds two new interactive lenses that take advantage of the layers of partially obscured documents to enhance the web IDE's visual experience.

- **Bioluminescent Trace Lens (Alt+Shift+T):** Applies a bio-glow and trace mask effect over obscured layers, interacting dynamically with the environment.
- **Digital Matrix Decode Lens (Alt+Shift+O):** Slices obscured layers into grid patterns with matrix-style effects, shifting hues to green and expanding depth.

**Testing Steps:**
1. Open the web IDE.
2. Ensure multiple document tabs are open to create layers in the background.
3. Hold `Alt+Shift+T` and observe the Bioluminescent Trace effect.
4. Hold `Alt+Shift+O` and observe the Digital Matrix Decode effect.

Automated tests and playwright smoke tests have been verified to pass. Screenshots and videos were recorded during frontend verification to ensure correct visual output.

---
*PR created automatically by Jules for task [18070707240386752612](https://jules.google.com/task/18070707240386752612) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Bioluminescent Trace Lens, activated with Alt+Shift+T.
  - Added the Digital Matrix Decode Lens, activated with Alt+Shift+O.
  - Lens modes now apply distinct visual treatments, including glowing highlights, masked editor views, document offsets, clipping effects, and animated borders or scanlines.
  - Hold the shortcut to activate a lens and release it to return to the standard view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->