### PR TITLE
feat(ui): add new interactive lenses and refine IDE styling

### DIFF
--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -512,6 +512,65 @@ export function registerLensBindings(manager, { doc = document } = {}) {
     onUp: () => body.classList.remove("loupe-active", "astral-projection-active"),
   });
 
+  manager.register({
+    id: "pixelate-lens",
+    category: "lens",
+    description: "Pixelate Lens (Alt+Shift+4)",
+    combo: { alt: true, shift: true, code: "Digit4" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "pixelate-lens-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "pixelate-lens-active"),
+  });
+
+  manager.register({
+    id: "vortex-warp",
+    category: "lens",
+    description: "Vortex Warp Lens (Alt+Shift+5)",
+    combo: { alt: true, shift: true, code: "Digit5" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "vortex-warp-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "vortex-warp-active"),
+  });
+
+  manager.register({
+    id: "echo-trails",
+    category: "lens",
+    description: "Echo Trails Lens (Alt+Shift+6)",
+    combo: { alt: true, shift: true, code: "Digit6" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "echo-trails-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "echo-trails-active"),
+  });
+
+
+
 
   manager.register({
     id: "xray-grid-lens",

--- a/src/styles_base.css
+++ b/src/styles_base.css
@@ -2,7 +2,7 @@
 
 /* ─── styles_1.css ─── */
 :root {
-  --bg-color-glass: rgba(16, 20, 30, 0.6);
+  --bg-color-glass: rgba(12, 16, 24, 0.7);
   --accent-color: hsl(var(--dynamic-hue), 80%, 60%);
   --text-primary: #c0d0e0;
   --text-heading: #ffffff;
@@ -572,8 +572,8 @@ textarea:focus {
   overflow: hidden;
 
   /* Enhanced Premium Glassmorphism */
-  background: rgba(15, 20, 35, 0.55);
-  backdrop-filter: blur(30px) saturate(180%);
+  background: rgba(12, 16, 28, 0.65);
+  backdrop-filter: blur(40px) saturate(200%);
   -webkit-backdrop-filter: blur(30px) saturate(180%);
   border: 1px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5), inset 0 1px 2px rgba(255, 255, 255, 0.1);

--- a/src/styles_views.css
+++ b/src/styles_views.css
@@ -3065,12 +3065,12 @@ body.peel-active #editor {
   transform: translateY(-50%);
   width: 48px;
   height: 350px;
-  background: linear-gradient(180deg, rgba(20, 30, 50, 0.75), rgba(5, 10, 20, 0.65));
-  backdrop-filter: blur(48px) saturate(250%);
+  background: linear-gradient(180deg, rgba(25, 40, 65, 0.8), rgba(10, 15, 30, 0.7));
+  backdrop-filter: blur(60px) saturate(300%);
   -webkit-backdrop-filter: blur(48px) saturate(250%);
   border: 1px solid rgba(0, 255, 255, 0.5);
   border-radius: 16px;
-  box-shadow:0 25px 60px rgba(0, 0, 0, 0.9), inset 0 0 35px rgba(0, 255, 255, 0.5), inset 0 1px 2px rgba(255, 255, 255, 0.2), 0 0 15px rgba(0, 255, 255, 0.2);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.95), inset 0 0 45px rgba(0, 255, 255, 0.6), inset 0 1px 3px rgba(255, 255, 255, 0.3), 0 0 25px rgba(0, 255, 255, 0.4);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -3856,4 +3856,113 @@ body.prismatic-array-active #editor {
   border-color: rgba(57, 255, 20, 1) !important;
   box-shadow: 0 0 40px rgba(57, 255, 20, 0.6), inset 0 0 20px rgba(57, 255, 20, 0.4) !important;
   z-index: 999 !important;
+}
+
+/* ─── Pixelate Lens ─────────────────────────────────────────────────── */
+body.pixelate-lens-active .echo-document {
+  transition: opacity 0.3s ease, filter 0.3s ease, transform 0.4s ease;
+  mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50%) var(--lens-y, 50%),
+    black 0%,
+    transparent 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50%) var(--lens-y, 50%),
+    black 0%,
+    transparent 100%
+  );
+  opacity: 0.9 !important;
+  /* Basic CSS pixelation technique uses crisp-edges and blur/contrast */
+  image-rendering: pixelated;
+  filter: blur(2px) contrast(2) drop-shadow(0 0 15px rgba(0, 255, 100, 0.5)) !important;
+  z-index: 300 !important;
+  transform: translate3d(
+    calc(var(--tx, 0px) * 1.05),
+    calc(var(--ty, 0px) * 1.05),
+    calc(var(--tz, -200px) + 50px)
+  ) rotateX(calc(var(--item-index, 0) * 2deg)) !important;
+}
+body.pixelate-lens-active #editor {
+  mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+}
+
+
+/* ─── Vortex Warp Lens ─────────────────────────────────────────────────── */
+body.vortex-warp-active .echo-document {
+  transition: opacity 0.3s ease, filter 0.3s ease, transform 0.4s ease;
+  mask-image: radial-gradient(
+    circle 350px at var(--lens-x, 50%) var(--lens-y, 50%),
+    black 0%,
+    transparent 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 350px at var(--lens-x, 50%) var(--lens-y, 50%),
+    black 0%,
+    transparent 100%
+  );
+  opacity: 0.9 !important;
+  filter: hue-rotate(calc(var(--item-index, 0) * 20deg)) brightness(1.2) drop-shadow(0 0 20px rgba(200, 50, 255, 0.4)) !important;
+  z-index: 300 !important;
+  transform: translate3d(
+    calc(var(--tx, 0px) + (sin(calc(var(--item-index, 0) * 0.5)) * 100px)),
+    calc(var(--ty, 0px) + (cos(calc(var(--item-index, 0) * 0.5)) * 100px)),
+    calc(var(--tz, -200px) + 100px)
+  ) rotateZ(calc(var(--item-index, 0) * 15deg)) !important;
+}
+body.vortex-warp-active #editor {
+  mask-image: radial-gradient(
+    circle 350px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 350px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+}
+
+
+/* ─── Echo Trails Lens ─────────────────────────────────────────────────── */
+body.echo-trails-active .echo-document {
+  transition: opacity 0.3s ease, filter 0.3s ease, transform 0.8s cubic-bezier(0.1, 0.9, 0.2, 1);
+  mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50%) var(--lens-y, 50%),
+    black 0%,
+    transparent 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50%) var(--lens-y, 50%),
+    black 0%,
+    transparent 100%
+  );
+  opacity: calc(0.9 - (var(--item-index, 0) * 0.05)) !important;
+  filter: blur(calc(var(--item-index, 0) * 1px)) drop-shadow(0 0 10px rgba(0, 200, 255, 0.3)) !important;
+  z-index: 300 !important;
+  transform: translate3d(
+    calc(var(--tx, 0px) + (var(--item-index, 0) * 20px)),
+    calc(var(--ty, 0px) - (var(--item-index, 0) * 10px)),
+    calc(var(--tz, -200px) - (var(--item-index, 0) * 50px))
+  ) scale(calc(1 - (var(--item-index, 0) * 0.05))) !important;
+}
+body.echo-trails-active #editor {
+  mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    black 100%
+  );
 }


### PR DESCRIPTION
Added three new interactive lenses (Pixelate, Vortex Warp, and Echo Trails) that manipulate partially obscured documents, and refined the overall visual styling of the web IDE with updated glassmorphism backgrounds.

---
*PR created automatically by Jules for task [3908539337936741464](https://jules.google.com/task/3908539337936741464) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three hold-to-activate visual lenses: Pixelate, Vortex Warp, and Echo Trails.
  * Added keyboard shortcuts: Alt+Shift+4, Alt+Shift+5, and Alt+Shift+6.
  * Lens modes are mutually exclusive and deactivate automatically when released.
* **Style**
  * Refined the glass background and enhanced dock transparency, blur, and color saturation.
  * Improved the slicer interface with brighter gradients, stronger visual depth, and lens-specific effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->