### PR TITLE
Improve UI formatting and add three new obscured-layer lenses

### DIFF
--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -591,6 +591,64 @@ export function registerLensBindings(manager, { doc = document } = {}) {
     onUp: () => body.classList.remove("loupe-active", "xray-grid-active"),
   });
 
+
+  manager.register({
+    id: "synapse-connect",
+    category: "lens",
+    description: "Synapse Connect Lens (Alt+Shift+7)",
+    combo: { alt: true, shift: true, code: "Digit7" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "synapse-connect-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "synapse-connect-active"),
+  });
+
+  manager.register({
+    id: "ethereal-ghost",
+    category: "lens",
+    description: "Ethereal Ghost Lens (Alt+Shift+8)",
+    combo: { alt: true, shift: true, code: "Digit8" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "ethereal-ghost-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "ethereal-ghost-active"),
+  });
+
+  manager.register({
+    id: "holographic-distortion",
+    category: "lens",
+    description: "Holographic Distortion Lens (Alt+Shift+9)",
+    combo: { alt: true, shift: true, code: "Digit9" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "holo-distortion-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "holo-distortion-active"),
+  });
+
   if (typeof doc.addEventListener === "function") {
     doc.addEventListener("mousemove", (e) => {
       if (!body.classList.contains("loupe-active")) return;

--- a/src/styles_base.css
+++ b/src/styles_base.css
@@ -61,7 +61,7 @@ body,
 }
 ::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.1);
-  border-radius: 10px;
+  border-radius: 4px;
 }
 ::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.25);
@@ -75,11 +75,11 @@ body,
   bottom: 0;
   z-index: 5; /* default: depth 1 — middle between rain layers; JS will update dynamically */
   box-shadow:
-    0 40px 80px rgba(0, 0, 0, 0.8),
+    0 4px 12px rgba(0, 0, 0, 0.8),
     inset 0 2px 10px rgba(255, 255, 255, 0.15),
     0 0 20px rgba(0, 229, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 16px;
+  border-radius: 4px;
 
   /* Cyber Grid Background */
   background-image:
@@ -366,7 +366,7 @@ body,
   height: 14px;
   background: rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 3px;
+  border-radius: 4px;
   cursor: pointer;
   position: relative;
   flex-shrink: 0;
@@ -390,7 +390,7 @@ body,
 #reference-layer code {
   background: rgba(255, 255, 255, 0.1);
   padding: 2px 4px;
-  border-radius: 3px;
+  border-radius: 4px;
   font-family: var(--font-mono);
   color: #aaddff;
 }
@@ -476,7 +476,7 @@ textarea {
   width: 100%;
   background: rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
+  border-radius: 4px;
   color: #c0c0d0;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -576,11 +576,11 @@ textarea:focus {
   backdrop-filter: blur(40px) saturate(200%);
   -webkit-backdrop-filter: blur(30px) saturate(180%);
   border: 1px solid rgba(255, 255, 255, 0.15);
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5), inset 0 1px 2px rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), inset 0 1px 2px rgba(255, 255, 255, 0.1);
   border-top: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 24px;
+  border-radius: 4px;
   box-shadow:
-    0 20px 40px rgba(0, 0, 0, 0.5),
+    0 4px 12px rgba(0, 0, 0, 0.5),
     0 0 75px rgba(0, 229, 255, 0.1),
     inset 0 1px 2px rgba(255, 255, 255, 0.15);
   z-index: 10000;
@@ -589,7 +589,7 @@ textarea:focus {
 
 #dock:hover {
   box-shadow:
-    0 25px 50px rgba(0, 0, 0, 0.6),
+    0 4px 12px rgba(0, 0, 0, 0.6),
     0 0 90px rgba(0, 229, 255, 0.2),
     inset 0 1px 3px rgba(255, 255, 255, 0.25);
 }
@@ -598,7 +598,7 @@ textarea:focus {
   content: "";
   position: absolute;
   inset: -2px;
-  border-radius: 14px;
+  border-radius: 4px;
   background: linear-gradient(
     45deg,
     rgba(255, 0, 128, 0.5),
@@ -615,7 +615,7 @@ textarea:focus {
 #dock:hover {
   transform: translateX(-50%) translate3d(var(--dock-tx, 0), calc(var(--dock-ty, 0) - 5px), 50px) rotateX(var(--dock-rot-x, 0)) rotateY(var(--dock-rot-y, 0));
   box-shadow:
-    0 40px 100px rgba(0, 0, 0, 0.95),
+    0 4px 12px rgba(0, 0, 0, 0.95),
     inset 0 1px 2px rgba(255, 255, 255, 0.4),
     0 0 80px rgba(0, 229, 255, 0.3),
     inset 0 0 20px rgba(0, 229, 255, 0.1);
@@ -662,7 +662,7 @@ textarea:focus {
   align-items: center !important;
   gap: 12px !important;
   padding: 8px 16px !important;
-  border-radius: 12px !important;
+  border-radius: 4px !important;
 }
 
 .dock-group label {
@@ -690,7 +690,7 @@ textarea:focus {
   height: 20px !important;
   background: rgba(10, 15, 25, 0.8) !important;
   border: 1px solid rgba(255, 255, 255, 0.2) !important;
-  border-radius: 20px !important;
+  border-radius: 4px !important;
   position: relative !important;
   cursor: pointer !important;
   outline: none !important;
@@ -710,7 +710,7 @@ textarea:focus {
   background: #aaddff !important;
   border-radius: 50% !important;
   transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) !important;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4) !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4) !important;
   transform: translateX(0) !important;
 }
 
@@ -733,7 +733,7 @@ textarea:focus {
   padding: 6px 12px !important;
   background: rgba(255, 255, 255, 0.05) !important;
   border: 1px solid rgba(255, 255, 255, 0.1) !important;
-  border-radius: 20px !important;
+  border-radius: 4px !important;
   cursor: pointer !important;
   transition: all 0.2s ease !important;
 }
@@ -750,7 +750,7 @@ textarea:focus {
   border: 1px solid rgba(255, 255, 255, 0.15) !important;
   color: #e0f0ff !important;
   padding: 8px 16px !important;
-  border-radius: 20px !important;
+  border-radius: 4px !important;
   font-family: var(--font-mono, "JetBrains Mono", monospace) !important;
   font-size: 11px !important;
   cursor: pointer !important;
@@ -784,7 +784,7 @@ textarea:focus {
     inset 0 1px 0 rgba(255, 255, 255, 0.2),
     inset 0 0 45px rgba(255, 0, 128, 0.25),
     0 0 60px rgba(0, 229, 255, 0.45); /* Subtle accent glow */
-  border-radius: 12px;
+  border-radius: 4px;
   background: rgba(10, 15, 25, 0.65);
   backdrop-filter: blur(50px) saturate(200%);
   -webkit-backdrop-filter: blur(50px) saturate(200%);
@@ -842,7 +842,7 @@ textarea:focus {
   width: 100%;
   padding: 10px;
   background: rgba(0, 20, 40, 0.4);
-  border-radius: 12px;
+  border-radius: 4px;
   border: 1px solid rgba(0, 229, 255, 0.2);
   backdrop-filter: blur(10px);
   box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.3);
@@ -876,7 +876,7 @@ input[type="range"] {
   width: 100%;
   height: 6px;
   background: rgba(0, 0, 0, 0.3);
-  border-radius: 3px;
+  border-radius: 4px;
   outline: none;
   margin-top: 8px;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
@@ -922,7 +922,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
   border: 1px solid rgba(0, 229, 255, 0.3);
   color: #00e5ff;
   padding: 4px 10px;
-  border-radius: 6px;
+  border-radius: 4px;
   cursor: pointer;
   font-size: 11px;
   font-family: inherit;
@@ -951,7 +951,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
   border: 1px solid rgba(0, 229, 255, 0.2);
   color: rgba(230, 240, 255, 0.9);
   padding: 4px 8px;
-  border-radius: 6px;
+  border-radius: 4px;
   cursor: pointer;
   font-size: 10px;
   font-family: inherit;
@@ -977,7 +977,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
   justify-content: center;
   pointer-events: none;
   border: 2px dashed rgba(0, 229, 255, 0.55);
-  border-radius: 16px;
+  border-radius: 4px;
   background: rgba(0, 20, 30, 0.45);
   color: #00e5ff;
   font-family: var(--font-mono, monospace);
@@ -991,7 +991,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
   border: 1px solid rgba(255, 0, 128, 0.3);
   color: #ff0080;
   padding: 4px 10px;
-  border-radius: 6px;
+  border-radius: 4px;
   cursor: pointer;
   font-size: 11px;
   font-family: inherit;
@@ -1092,12 +1092,12 @@ input[type="checkbox"]:hover {
   -webkit-backdrop-filter: blur(48px) saturate(200%);
 
   padding: 40px;
-  border-radius: 24px;
+  border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.08);
 
   /* Depth Shadow */
   box-shadow:
-    0 24px 64px rgba(0, 0, 0, 0.6),
+    0 4px 12px rgba(0, 0, 0, 0.6),
     0 8px 24px rgba(0, 0, 0, 0.4),
     0 0 0 1px rgba(255, 255, 255, 0.05),
     /* Inner light border */ inset 0 1px 1px rgba(255, 255, 255, 0.15),
@@ -1142,7 +1142,7 @@ input[type="checkbox"]:hover {
   z-index: 100 !important;
   transform: scale(1.05) !important;
   box-shadow:
-    0 30px 60px rgba(0, 0, 0, 0.5),
+    0 4px 12px rgba(0, 0, 0, 0.5),
     0 0 30px rgba(0, 229, 255, 0.4),
     inset 0 0 20px rgba(0, 229, 255, 0.1);
   border-color: rgba(0, 229, 255, 0.5);
@@ -1166,7 +1166,7 @@ input[type="checkbox"]:hover {
   -webkit-backdrop-filter: blur(48px) saturate(120%);
   border-color: rgba(255, 255, 255, 0.4);
   box-shadow:
-    0 10px 30px rgba(0, 0, 0, 0.3),
+    0 4px 12px rgba(0, 0, 0, 0.3),
     inset 0 0 40px rgba(255, 255, 255, 0.2);
   color: #eef8ff;
   pointer-events: none; /* Disable interaction */
@@ -1197,7 +1197,7 @@ input[type="checkbox"]:hover {
 .note-card[data-tags*="#bug"] {
   border-color: rgba(255, 50, 50, 0.4);
   box-shadow:
-    0 8px 32px rgba(50, 0, 0, 0.3),
+    0 4px 12px rgba(50, 0, 0, 0.3),
     inset 0 0 20px rgba(255, 0, 0, 0.05);
 }
 .note-card[data-tags*="#bug"]::before {
@@ -1317,7 +1317,7 @@ input[type="checkbox"]:hover {
   50% {
     border-color: rgba(0, 229, 255, 0.4);
     box-shadow:
-      0 10px 40px rgba(0, 229, 255, 0.15),
+    0 4px 12px rgba(0, 229, 255, 0.15),
       inset 0 1px 0 rgba(255, 255, 255, 0.1);
   }
   100% {
@@ -1384,7 +1384,7 @@ input[type="checkbox"]:hover {
 .note-card pre {
   background: rgba(0, 5, 10, 0.5);
   padding: 16px;
-  border-radius: 12px;
+  border-radius: 4px;
   overflow-x: auto;
   margin: 20px 0;
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -1401,7 +1401,7 @@ input[type="checkbox"]:hover {
 .note-card :not(pre) > code {
   background: rgba(0, 229, 255, 0.1);
   padding: 4px 8px;
-  border-radius: 6px;
+  border-radius: 4px;
   border: 1px solid rgba(0, 229, 255, 0.2);
   color: #ccffff;
   text-shadow: 0 0 6px rgba(0, 229, 255, 0.3);
@@ -1413,7 +1413,7 @@ input[type="checkbox"]:hover {
   font-style: italic;
   background: linear-gradient(90deg, rgba(0, 229, 255, 0.1), transparent);
   padding: 12px 16px;
-  border-radius: 0 8px 8px 0;
+  border-radius: 0 4px 4px 0;
 }
 /* Tables */
 .md-table {
@@ -1476,7 +1476,7 @@ body.theme-journal .note-card {
   color: #333;
   font-family: "Courier New", Courier, serif;
   border: 1px solid rgba(0, 0, 0, 0.1);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
 }
@@ -1612,7 +1612,7 @@ body.theme-blueprint #rain-front {
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-bottom: 2px solid rgba(255, 255, 255, 0.2);
 
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 
   white-space: nowrap;
   opacity: 0.85;
@@ -1982,10 +1982,10 @@ body.theme-blueprint #rain-front {
   padding: 16px 20px;
   border-left: 4px solid #ccc;
   background: rgba(255, 255, 255, 0.05);
-  border-radius: 0 8px 8px 0;
+  border-radius: 0 4px 4px 0;
   font-size: 14px;
   color: #e0e0e0;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .callout.note {
@@ -2040,7 +2040,7 @@ body.theme-blueprint #rain-front {
   content: "";
   position: absolute;
   inset: -2px;
-  border-radius: 14px;
+  border-radius: 4px;
   background: linear-gradient(
     90deg,
     rgba(0, 229, 255, 0.6),
@@ -2061,7 +2061,7 @@ body.theme-blueprint #rain-front {
 #tabs-container:hover {
   background: rgba(12, 16, 24, 0.98);
   box-shadow:
-    0 50px 100px rgba(0, 0, 0, 0.98),
+    0 4px 12px rgba(0, 0, 0, 0.98),
     inset 0 1px 1px rgba(255, 255, 255, 0.4),
     0 0 80px rgba(0, 229, 255, 0.6);
 }
@@ -2083,7 +2083,7 @@ body.theme-blueprint #rain-front {
   align-items: center;
   gap: 12px;
   padding: 8px 20px;
-  border-radius: 14px;
+  border-radius: 4px;
   cursor: pointer;
   font-size: 13px;
   font-weight: 800;
@@ -2096,7 +2096,7 @@ body.theme-blueprint #rain-front {
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   border-top: 1px solid rgba(255, 255, 255, 0.15);
   box-shadow:
-    0 8px 24px rgba(0, 0, 0, 0.7),
+    0 4px 12px rgba(0, 0, 0, 0.7),
     inset 0 1px 2px rgba(255, 255, 255, 0.1);
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   white-space: nowrap;
@@ -2115,7 +2115,7 @@ body.theme-blueprint #rain-front {
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   color: #fff;
   box-shadow:
-    0 12px 30px rgba(0, 0, 0, 0.8),
+    0 4px 12px rgba(0, 0, 0, 0.8),
     inset 0 1px 2px rgba(255, 255, 255, 0.2);
   transform: translateY(-2px) scale(1.03);
   text-shadow: 0 0 10px rgba(0, 229, 255, 1);
@@ -2146,7 +2146,7 @@ body.theme-blueprint #rain-front {
   border-bottom: 1px solid rgba(0, 229, 255, 0.5);
   color: #ffffff;
   box-shadow:
-    0 20px 50px rgba(0, 0, 0, 0.95),
+    0 4px 12px rgba(0, 0, 0, 0.95),
     inset 0 1px 5px rgba(255, 255, 255, 0.4),
     0 0 20px rgba(0, 229, 255, 0.4);
   transform: translateY(-4px) scale(1.08);
@@ -2181,7 +2181,7 @@ body.theme-blueprint #rain-front {
   font-size: 9px;
   line-height: 1;
   padding: 2px 6px;
-  border-radius: 10px;
+  border-radius: 4px;
   font-weight: bold;
   letter-spacing: 0;
 }
@@ -2209,7 +2209,7 @@ body.theme-blueprint #rain-front {
   flex-shrink: 0;
   background: rgba(0, 0, 0, 0.3);
   padding: 6px 12px;
-  border-radius: 8px;
+  border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.05);
 }
 .depth-controls button {
@@ -2219,7 +2219,7 @@ body.theme-blueprint #rain-front {
   font-family: var(--font-primary);
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
+  border-radius: 4px;
   box-shadow: none;
   color: #fff;
   cursor: pointer;
@@ -2246,7 +2246,7 @@ body.theme-blueprint #rain-front {
   font-family: var(--font-primary);
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
+  border-radius: 4px;
   color: #fff;
   cursor: pointer;
   outline: none;
@@ -2281,7 +2281,7 @@ body.theme-blueprint #rain-front {
   width: 20px;
   height: 20px;
   border: 1px solid rgba(255, 255, 255, 0.25);
-  border-radius: 6px;
+  border-radius: 4px;
   background: rgba(0, 0, 0, 0.35);
   color: #e6f6ff;
   font-size: 11px;
@@ -2318,8 +2318,8 @@ body.theme-blueprint #rain-front {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.8);
-  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
@@ -2361,7 +2361,7 @@ body.x-ray-active #echo-layer {
   left: 10%;
   width: 80%;
   height: 80%;
-  border-radius: 24px;
+  border-radius: 4px;
   pointer-events: auto; /* Allow hovering to peek */
   cursor: pointer;
   font-family: var(--font-mono);
@@ -2420,11 +2420,11 @@ body.x-ray-active #echo-layer {
   border: 1px solid hsla(var(--echo-tint, 0deg), 100%, 80%, 0.6);
   border-top: 1px solid hsla(var(--echo-tint, 0deg), 100%, 90%, 0.8);
   border-left: 1px solid hsla(var(--echo-tint, 0deg), 100%, 80%, 0.6);
-  border-radius: 22px;
+  border-radius: 4px;
   padding: 24px;
   box-sizing: border-box;
   box-shadow:
-    0 30px 90px rgba(0, 0, 0, 0.95),
+    0 4px 12px rgba(0, 0, 0, 0.95),
     inset 0 2px 3px rgba(255, 255, 255, 0.4),
     0 0 50px hsla(var(--echo-tint, 0deg), 100%, 60%, 0.25),
     inset 0 0 40px hsla(var(--echo-tint, 0deg), 100%, 70%, 0.25);
@@ -2434,7 +2434,7 @@ body.x-ray-active #echo-layer {
   content: "";
   position: absolute;
   inset: -1px;
-  border-radius: 20px;
+  border-radius: 4px;
   padding: 1px;
   background: linear-gradient(
     45deg,
@@ -2534,7 +2534,7 @@ body.flashlight-active .echo-document {
   opacity: 0.5;
   z-index: 1;
   animation: echo-gradient-shift 12s ease-in-out infinite alternate;
-  border-radius: 20px;
+  border-radius: 4px;
 }
 
 @keyframes echo-gradient-shift {
@@ -2569,7 +2569,7 @@ body.flashlight-active .echo-document {
   content: "";
   position: absolute;
   inset: -4px;
-  border-radius: 28px;
+  border-radius: 4px;
   border: 2px dashed rgba(0, 229, 255, 0.4);
   pointer-events: none;
   animation: holo-ring-spin 20s linear infinite;
@@ -2599,7 +2599,7 @@ body.flashlight-active .echo-document {
 .echo-document-holo-ring {
   position: absolute;
   inset: -6px;
-  border-radius: 30px;
+  border-radius: 4px;
   border: 2px dashed rgba(0, 229, 255, 0.5);
   pointer-events: none;
   animation: holo-ring-spin 10s linear infinite;
@@ -2652,7 +2652,7 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
 .echo-document {
   /* Enhanced glowing edge and deepened shadow */
   box-shadow:
-    0 50px 110px rgba(0, 0, 0, 0.85),
+    0 4px 12px rgba(0, 0, 0, 0.85),
     inset 0 2px 5px rgba(255, 255, 255, 0.3),
     inset 0 0 25px hsla(var(--echo-tint, 0deg), 100%, 60%, 0.15),
     0 0 20px rgba(0, 229, 255, 0.2),
@@ -2679,7 +2679,7 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
   /* Deep Layer Breathing */
   animation: deep-pulse calc(10s + (var(--index, 0) * 2s)) infinite alternate
     ease-in-out;
-  border-radius: 12px;
+  border-radius: 4px;
   background: linear-gradient(
     135deg,
     rgba(255, 255, 255, 0.02) 0%,
@@ -2718,7 +2718,7 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
 
   /* Breathing Glow border animation (only highly active when awake) */
   box-shadow:
-    0 40px 100px rgba(0, 0, 0, 1),
+    0 4px 12px rgba(0, 0, 0, 1),
     inset 0 1px 3px rgba(255, 255, 255, 0.4),
     inset 0 0 calc(80px + (var(--wake) * 50px))
       hsla(var(--echo-tint, 0deg), 100%, 60%, calc(0.15 + var(--wake) * 0.25)),
@@ -2732,7 +2732,7 @@ body.rolodex-active .echo-document:hover .echo-document-holo-ring {
   color: #00e5ff;
   border: 1px solid rgba(0, 229, 255, 0.3);
   padding: 8px 16px;
-  border-radius: 20px;
+  border-radius: 4px;
   font-family: var(--font-mono, "JetBrains Mono", monospace);
   font-size: 12px;
   outline: none;

--- a/src/styles_echo.css
+++ b/src/styles_echo.css
@@ -103,7 +103,7 @@ body.solar-system-active #echo-layer::before {
   /* Golden/Warning glow to indicate a search match */
   border: 1px solid rgba(0, 255, 204, 1) !important;
   box-shadow:
-    0 20px 50px rgba(0, 255, 204, 0.6),
+    0 4px 12px rgba(0, 255, 204, 0.6),
     0 0 60px rgba(0, 255, 204, 0.8),
     inset 0 0 40px rgba(0, 255, 204, 0.4) !important;
 
@@ -138,11 +138,11 @@ body.solar-system-active #echo-layer::before {
   /* Enhanced Neon border styling */
   border: 1px solid rgba(0, 255, 255, 0.5);
   box-shadow:
-    0 16px 48px rgba(0, 0, 0, 0.6),
+    0 4px 12px rgba(0, 0, 0, 0.6),
     0 0 25px rgba(0, 229, 255, 0.3),
     inset 0 0 20px rgba(0, 229, 255, 0.15),
     inset 0 2px 2px rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
+  border-radius: 4px;
   position: relative;
   overflow: hidden;
 }
@@ -209,9 +209,9 @@ body.solar-system-active #echo-layer::before {
   backdrop-filter: blur(32px) saturate(200%);
   -webkit-backdrop-filter: blur(32px) saturate(200%);
   border: 1px solid rgba(255, 255, 255, 0.25);
-  border-radius: 16px;
+  border-radius: 4px;
   box-shadow:
-    0 15px 45px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     inset 0 1px 2px rgba(255, 255, 255, 0.5),
     0 0 30px rgba(0, 229, 255, 0.2);
   color: #aaddff;
@@ -232,7 +232,7 @@ body.solar-system-active #echo-layer::before {
     rgba(15, 25, 35, 0.8) 100%
   );
   box-shadow:
-    0 18px 50px rgba(0, 0, 0, 0.95),
+    0 4px 12px rgba(0, 0, 0, 0.95),
     inset 0 1px 3px rgba(255, 255, 255, 0.6),
     0 0 30px rgba(0, 229, 255, 0.5);
   transform: translateX(-50%) translateY(-2px);
@@ -252,7 +252,7 @@ body.solar-system-active #echo-layer::before {
 
   /* Apply our dynamic Bioluminescent glow from earlier */
   box-shadow:
-    0 10px 30px var(--bio-glow-color, rgba(0, 229, 255, 0.6)),
+    0 4px 12px var(--bio-glow-color, rgba(0, 229, 255, 0.6)),
     0 0 15px var(--bio-glow-strong, rgba(0, 229, 255, 0.9)),
     inset 0 0 10px rgba(255, 255, 255, 0.2);
 
@@ -443,14 +443,14 @@ body.infinity-mirror-active .echo-document:hover {
     opacity 0.8s ease-out,
     filter 0.8s;
   box-shadow:
-    0 10px 40px rgba(0, 0, 0, 0.8),
+    0 4px 12px rgba(0, 0, 0, 0.8),
     0 0 20px rgba(0, 255, 255, 0.2);
   border: 1px solid rgba(0, 255, 255, 0.3);
   backdrop-filter: blur(10px);
 }
 .carousel-active .echo-document:hover {
   box-shadow:
-    0 15px 50px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     0 0 30px rgba(0, 255, 255, 0.5);
   border-color: rgba(0, 255, 255, 0.6);
 }
@@ -564,7 +564,7 @@ body.cyber-cortex-active .echo-document {
 body.cyber-cortex-active .echo-document:hover {
   opacity: 1 !important;
   filter: blur(0px) !important;
-  border-radius: 12px; /* Morph back to a readable rectangle */
+  border-radius: 4px; /* Morph back to a readable rectangle */
   width: 600px;
   height: 800px;
   transform: translate3d(
@@ -761,7 +761,7 @@ body.hologram-preview-active #echo-layer .echo-document.hologram-target {
   backdrop-filter: blur(10px) sepia(50%) hue-rotate(180deg) !important;
   border: 2px solid rgba(0, 255, 255, 0.8) !important;
   box-shadow:
-    0 20px 60px rgba(0, 255, 255, 0.5),
+    0 4px 12px rgba(0, 255, 255, 0.5),
     inset 0 0 30px rgba(0, 255, 255, 0.3) !important;
 }
 body.hologram-preview-active #echo-layer .echo-document.hologram-target::after {
@@ -807,7 +807,7 @@ body.outline-active .tab-depth-badge.depth-2 {
 body.outline-active .echo-document {
   border: 1px solid hsla(var(--echo-tint, 180deg), 100%, 70%, 0.65);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.5),
+    0 4px 12px rgba(0, 0, 0, 0.5),
     0 0 0 1px hsla(var(--echo-tint, 180deg), 100%, 60%, 0.35),
     inset 0 0 30px hsla(var(--echo-tint, 180deg), 100%, 60%, 0.15);
   opacity: calc(var(--base-opacity, 0.4) + 0.2);
@@ -815,7 +815,7 @@ body.outline-active .echo-document {
     hue-rotate(var(--echo-tint, 0deg));
   backdrop-filter: blur(10px) saturate(160%);
   background: linear-gradient(135deg, rgba(15, 20, 25, 0.6), rgba(5, 10, 15, 0.8));
-  border-radius: 12px;
+  border-radius: 4px;
   transform: scale(0.95);
   transition: all 0.4s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
@@ -823,7 +823,7 @@ body.outline-active .echo-document {
 body.outline-active .echo-document:hover {
   border-color: hsla(var(--echo-tint, 180deg), 100%, 80%, 1) !important;
   box-shadow:
-    0 15px 45px rgba(0, 0, 0, 0.6),
+    0 4px 12px rgba(0, 0, 0, 0.6),
     0 0 0 2px hsla(var(--echo-tint, 180deg), 100%, 80%, 0.6),
     0 0 40px hsla(var(--echo-tint, 180deg), 100%, 70%, 0.3),
     inset 0 0 40px hsla(var(--echo-tint, 180deg), 100%, 70%, 0.2) !important;
@@ -878,7 +878,7 @@ body.outline-active .echo-header::before {
 .echo-focus-outline-btn {
   background: transparent;
   border: 1px solid hsla(var(--echo-tint, 180deg), 100%, 60%, 0.4);
-  border-radius: 6px;
+  border-radius: 4px;
   color: hsla(var(--echo-tint, 180deg), 100%, 70%, 0.8);
   cursor: pointer;
   font-size: 14px;
@@ -907,7 +907,7 @@ body.outline-active .echo-header::before {
 .echo-symbol-outline {
   margin: 8px 0 6px;
   border: 1px solid hsla(var(--echo-tint, 180deg), 90%, 65%, 0.4);
-  border-radius: 12px;
+  border-radius: 4px;
   background: rgba(10, 15, 25, 0.65);
   backdrop-filter: blur(8px) saturate(120%);
   overflow: hidden;
@@ -918,11 +918,11 @@ body.outline-active .echo-header::before {
     box-shadow 0.4s ease;
   max-height: 300px;
   opacity: 1;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .echo-symbol-outline:hover {
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.6), 0 0 15px hsla(var(--echo-tint, 180deg), 70%, 50%, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 15px hsla(var(--echo-tint, 180deg), 70%, 50%, 0.2);
   border-color: hsla(var(--echo-tint, 180deg), 100%, 75%, 0.6);
 }
 
@@ -1000,7 +1000,7 @@ body.outline-active .echo-header::before {
 
 .echo-outline-list::-webkit-scrollbar-thumb {
   background: hsla(var(--echo-tint, 180deg), 100%, 60%, 0.3);
-  border-radius: 2px;
+  border-radius: 4px;
 }
 
 .echo-outline-item {
@@ -1128,7 +1128,7 @@ body.veil-excavator-active #echo-layer .echo-document {
   box-shadow: 0 0 15px rgba(0, 229, 255, 0.3);
   color: #00e5ff;
   padding: 10px 20px;
-  border-radius: 8px;
+  border-radius: 4px;
   z-index: 9999;
   text-align: center;
   font-family: var(--font-mono);
@@ -1288,7 +1288,7 @@ body.cyclone-active .echo-document {
      We will make the documents glow and have a wind-like distortion. */
   border: 1px solid rgba(0, 229, 255, 0.3);
   box-shadow:
-    0 10px 40px rgba(0, 0, 0, 0.8),
+    0 4px 12px rgba(0, 0, 0, 0.8),
     0 0 30px rgba(0, 255, 255, 0.2);
   backdrop-filter: blur(10px);
 }
@@ -1298,7 +1298,7 @@ body.cyclone-active .echo-document:hover {
   filter: blur(0px) brightness(1.5) !important;
   border-color: rgba(0, 255, 255, 0.8);
   box-shadow:
-    0 15px 50px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     0 0 50px rgba(0, 255, 255, 0.6);
   transform: translate3d(
       calc(var(--tx, 0px) + var(--part-tx, 0px) + var(--repel-tx, 0px) + var(--repulse-tx, 0px)),
@@ -1728,7 +1728,7 @@ body.luminescence-active .echo-document:hover {
     )
     rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1.2) !important;
   z-index: 50 !important;
-  border-radius: 12px; /* Return to readable shape on hover */
+  border-radius: 4px; /* Return to readable shape on hover */
   box-shadow:
     0 0 60px var(--glow-color, rgba(255, 255, 255, 0.8)),
     inset 0 0 30px var(--glow-color, rgba(255, 255, 255, 0.4)) !important;
@@ -1821,13 +1821,13 @@ body.depth-beam-active #depth-beam {
   position: absolute;
   transition: all 0.35s cubic-bezier(0.23, 1, 0.32, 1);
   transform-style: preserve-3d;
-  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.4);
+  box-shadow: 0 4px 12px -12px rgb(0 0 0 / 0.4);
   backdrop-filter: blur(16px);
 
   /* Neon glassmorphism base */
   background: rgba(15, 23, 42, 0.65);
   border: 1px solid rgba(0, 229, 255, 0.3);
-  border-radius: 12px;
+  border-radius: 4px;
 
   /* Neon glow */
   box-shadow:

--- a/src/styles_ui.css
+++ b/src/styles_ui.css
@@ -13,7 +13,7 @@ body.holographic-slice-active .echo-document {
   );
   transition: clip-path 0.1s ease-out;
   border-bottom: 2px solid rgba(0, 255, 200, 0.8);
-  box-shadow: 0 5px 25px rgba(0, 255, 200, 0.4);
+  box-shadow: 0 4px 12px rgba(0, 255, 200, 0.4);
 }
 
 body.holographic-slice-active #editor {
@@ -86,7 +86,7 @@ body.tornado-active .echo-document {
   transition: all 0.8s cubic-bezier(0.16, 1, 0.3, 1);
   opacity: 0.6;
   filter: blur(3px) sepia(0.3) hue-rotate(-20deg);
-  border-radius: 12px;
+  border-radius: 4px;
 }
 
 body.tornado-active .echo-document:hover {
@@ -159,7 +159,7 @@ body.bookshelf-active .echo-document:hover {
   opacity: 1;
   filter: blur(0px) brightness(1.1);
   z-index: 100;
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.9), 0 0 40px rgba(0, 229, 255, 0.5);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 40px rgba(0, 229, 255, 0.5);
   border-color: #00e5ff;
 }
 
@@ -172,7 +172,7 @@ body.drawer-peek-ready .echo-document:not(.active) {
 body.drawer-peek-ready .echo-document:not(.active):hover {
   transform: translateX(350px) translateZ(100px) scale(1.05) !important;
   z-index: 1000 !important;
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.9), 0 0 40px rgba(0, 229, 255, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 40px rgba(0, 229, 255, 0.3);
   filter: blur(0px) brightness(1.2) !important;
   opacity: 1 !important;
 }
@@ -220,7 +220,7 @@ body.ribbon-active .echo-document {
   transition: all 0.8s cubic-bezier(0.25, 1, 0.5, 1);
   transform-origin: center center;
   opacity: 0.8;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 body.ribbon-active .echo-document:hover {
   opacity: 1 !important;
@@ -237,7 +237,7 @@ body.ribbon-active .echo-document:hover {
 /* Quick Polish Overrides */
 #editor {
   box-shadow:
-    0 30px 80px rgba(0, 0, 0, 0.8),
+    0 4px 12px rgba(0, 0, 0, 0.8),
     inset 0 1px 2px rgba(255, 255, 255, 0.1),
     inset 0 0 10px rgba(0, 229, 255, 0.05),
     inset 5px 5px 20px rgba(255, 255, 255, 0.02) !important;
@@ -269,7 +269,7 @@ body.fanning-active .echo-document:hover {
 /* Fix Dark Glass Dynamic Highlights and Grain */
 #editor {
   box-shadow:
-    0 30px 80px rgba(0, 0, 0, 0.8),
+    0 4px 12px rgba(0, 0, 0, 0.8),
     inset 0 1px 2px rgba(255, 255, 255, 0.1),
     inset calc(cos(var(--highlight-angle, 0deg)) * 10px)
       calc(sin(var(--highlight-angle, 0deg)) * 10px) 20px
@@ -315,11 +315,11 @@ body.fanning-active .echo-document:hover {
 }
 ::-webkit-scrollbar-track {
   background: rgba(10, 10, 15, 0.8);
-  border-radius: 6px;
+  border-radius: 4px;
 }
 ::-webkit-scrollbar-thumb {
   background: linear-gradient(180deg, #00f0ff, #ff003c);
-  border-radius: 6px;
+  border-radius: 4px;
   border: 2px solid rgba(10, 10, 15, 0.8);
 }
 ::-webkit-scrollbar-thumb:hover {
@@ -453,7 +453,7 @@ body.portal-mode-active::before {
   transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.4s ease, filter 0.4s ease, box-shadow 0.4s ease;
   transform: translate3d(var(--tx, 0), var(--ty, 0), var(--tz, 0)) rotateZ(var(--rot-z, 0));
   transform-origin: center center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
 .fibonacci-spiral-active .echo-document:not(.active):hover {
@@ -461,7 +461,7 @@ body.portal-mode-active::before {
   filter: blur(0px) saturate(1.2);
   transform: translate3d(var(--tx, 0), var(--ty, 0), calc(var(--tz, 0) + 150px)) rotateZ(var(--rot-z, 0)) scale(1.1);
   z-index: 1000;
-  box-shadow: 0 10px 40px rgba(0, 255, 204, 0.4), inset 0 0 0 1px rgba(0, 255, 204, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 255, 204, 0.4), inset 0 0 0 1px rgba(0, 255, 204, 0.3);
   cursor: pointer;
 }
 
@@ -611,13 +611,13 @@ body.pulse-wave-active .echo-document {
 /* 2. Editor Aurora Border Spin */
 #editor {
   position: relative;
-  border-radius: 12px;
+  border-radius: 4px;
 }
 #editor::before {
   content: "";
   position: absolute;
   inset: -2px;
-  border-radius: 14px;
+  border-radius: 4px;
   background: linear-gradient(
     45deg,
     rgba(0, 229, 255, 0.8),
@@ -772,7 +772,7 @@ body.fold-out-gallery-active .echo-document:hover {
   opacity: 1 !important;
   filter: none !important;
   z-index: 200 !important;
-  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.9), 0 0 40px rgba(0, 229, 255, 0.5);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 40px rgba(0, 229, 255, 0.5);
   border-color: rgba(0, 229, 255, 0.8);
 }
 
@@ -803,7 +803,7 @@ body.cityscape-active .echo-document:hover {
     scale(var(--scale, 1));
   opacity: 0.9;
   border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.6), inset 0 1px 1px rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), inset 0 1px 1px rgba(255, 255, 255, 0.1);
 }
 
 .house-of-cards-active .echo-document:hover {
@@ -815,7 +815,7 @@ body.cityscape-active .echo-document:hover {
     rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1.1);
   opacity: 1;
   z-index: 999 !important;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.8), 0 0 20px rgba(0, 255, 255, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 20px rgba(0, 255, 255, 0.3);
   border-color: rgba(0, 255, 255, 0.5);
 }
 
@@ -872,7 +872,7 @@ body.stack-deck-active .echo-document {
   transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1), opacity 0.5s ease;
   transform: translate3d(var(--tx, 0), var(--ty, 0), var(--tz, 0))
              rotateX(var(--rot-x, 0)) rotateY(var(--rot-y, 0)) rotateZ(var(--rot-z, 0));
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(10, 10, 15, 0.85);
   backdrop-filter: blur(10px);
@@ -881,14 +881,14 @@ body.stack-deck-active .echo-document {
 body.stack-deck-active .echo-document:hover {
   transform: translate3d(var(--tx, 0), calc(var(--ty, 0) - 20px), calc(var(--tz, 0) + 10px))
              rotateX(var(--rot-x, 0)) rotateY(var(--rot-y, 0)) rotateZ(var(--rot-z, 0));
-  box-shadow: 0 15px 40px rgba(0, 255, 200, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 255, 200, 0.4);
   border-color: rgba(0, 255, 200, 0.5);
   z-index: 1000 !important;
 }
 
 body.stack-deck-active #editor {
   z-index: 100;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   border: 1px solid rgba(0, 255, 200, 0.3);
 }
 
@@ -1548,7 +1548,7 @@ body.ectoplasmic-ooze-active .echo-document {
     rgba(0, 0, 0, 0) 100%
   );
   border-bottom: 5px solid rgba(128, 255, 0, 0.8) !important;
-  border-radius: 10px 10px 40% 40% !important;
+  border-radius: 4px !important;
 }
 
 /* Cosmic Void Lens (Alt+Shift+V) */
@@ -1781,7 +1781,7 @@ body.bioluminescent-trace-active .echo-document::before {
   position: absolute;
   inset: -10px;
   border: 2px dashed rgba(0, 255, 200, 0.5);
-  border-radius: 12px;
+  border-radius: 4px;
   animation: bioluminescent-pulse 2s infinite ease-in-out alternate;
   pointer-events: none;
   z-index: -1;
@@ -1996,10 +1996,10 @@ body.time-lapse-echo-active #editor {
   max-height: 86vh;
   overflow-y: auto;
   padding: 28px 32px;
-  border-radius: 14px;
+  border-radius: 4px;
   border: 1px solid rgba(90, 200, 250, 0.35);
   background: linear-gradient(160deg, rgba(10, 18, 34, 0.96), rgba(6, 10, 22, 0.96));
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(90, 200, 250, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(90, 200, 250, 0.08);
   color: #e6f1ff;
 }
 
@@ -2044,7 +2044,7 @@ body.time-lapse-echo-active #editor {
   flex: 0 0 auto;
   min-width: 92px;
   padding: 2px 8px;
-  border-radius: 5px;
+  border-radius: 4px;
   border: 1px solid rgba(90, 200, 250, 0.35);
   background: rgba(90, 200, 250, 0.1);
   color: #bfe9ff;
@@ -2054,4 +2054,148 @@ body.time-lapse-echo-active #editor {
 
 #keyboard-cheatsheet .cheatsheet-row span {
   opacity: 0.85;
+}
+
+/* =========================================
+   SYNAPSE CONNECT LENS (Alt+Shift+7)
+   ========================================= */
+body.synapse-connect-active #editor {
+  mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    transparent 40%,
+    rgba(0, 0, 0, 1) 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 250px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    transparent 40%,
+    rgba(0, 0, 0, 1) 100%
+  );
+  pointer-events: none;
+}
+
+body.synapse-connect-active .echo-document {
+  border: 1px solid rgba(0, 255, 200, 0.5);
+  box-shadow: 0 0 20px rgba(0, 255, 200, 0.2);
+  transform: translateZ(calc(var(--item-index, 0) * -30px)) scale(0.95);
+  animation: synapse-pulse 2s infinite alternate;
+}
+
+@keyframes synapse-pulse {
+  0% { box-shadow: 0 0 10px rgba(0, 255, 200, 0.2); border-color: rgba(0, 255, 200, 0.3); }
+  100% { box-shadow: 0 0 30px rgba(0, 255, 200, 0.6); border-color: rgba(0, 255, 200, 0.8); }
+}
+
+body.synapse-connect-active .echo-document::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 200%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(0, 255, 200, 0.8), transparent);
+  transform: translate(-50%, -50%) rotate(calc(var(--item-index, 0) * 15deg));
+  z-index: -1;
+  pointer-events: none;
+  animation: synapse-line-flow 3s linear infinite;
+}
+
+@keyframes synapse-line-flow {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+
+/* =========================================
+   ETHEREAL GHOST LENS (Alt+Shift+8)
+   ========================================= */
+body.ethereal-ghost-active #editor {
+  mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    transparent 20%,
+    rgba(0, 0, 0, 1) 80%
+  );
+  -webkit-mask-image: radial-gradient(
+    circle 300px at var(--lens-x, 50%) var(--lens-y, 50%),
+    transparent 0%,
+    transparent 20%,
+    rgba(0, 0, 0, 1) 80%
+  );
+}
+
+body.ethereal-ghost-active .echo-document {
+  opacity: 0.7;
+  filter: blur(2px) drop-shadow(0 0 15px rgba(200, 200, 255, 0.5));
+  animation: ethereal-float 6s ease-in-out infinite alternate;
+}
+
+@keyframes ethereal-float {
+  0% {
+    transform: translateY(0px) rotateX(2deg) rotateY(-2deg) scale(0.98);
+    filter: blur(2px) hue-rotate(0deg);
+  }
+  50% {
+    transform: translateY(-15px) rotateX(-2deg) rotateY(2deg) scale(1.02);
+    filter: blur(4px) hue-rotate(30deg);
+  }
+  100% {
+    transform: translateY(10px) rotateX(4deg) rotateY(-4deg) scale(0.95);
+    filter: blur(1px) hue-rotate(-30deg);
+  }
+}
+
+
+/* =========================================
+   HOLOGRAPHIC DISTORTION LENS (Alt+Shift+9)
+   ========================================= */
+body.holo-distortion-active #editor {
+  mask-image: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 10px,
+    rgba(0,0,0,1) 10px,
+    rgba(0,0,0,1) 20px
+  );
+  -webkit-mask-image: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 10px,
+    rgba(0,0,0,1) 10px,
+    rgba(0,0,0,1) 20px
+  );
+  opacity: 0.5;
+}
+
+body.holo-distortion-active .echo-document {
+  animation: holo-glitch-anim 0.3s infinite alternate;
+  mix-blend-mode: screen;
+}
+
+@keyframes holo-glitch-anim {
+  0% {
+    transform: translate(2px, 1px) skewX(2deg);
+    filter: drop-shadow(-3px 0 0 rgba(255, 0, 0, 0.8)) drop-shadow(3px 0 0 rgba(0, 255, 255, 0.8));
+  }
+  20% {
+    transform: translate(-2px, -1px) skewX(-2deg);
+    filter: drop-shadow(-1px 0 0 rgba(255, 0, 0, 0.8)) drop-shadow(1px 0 0 rgba(0, 255, 255, 0.8));
+  }
+  40% {
+    transform: translate(1px, 2px) skewX(1deg);
+    filter: drop-shadow(-4px 0 0 rgba(255, 0, 0, 0.8)) drop-shadow(4px 0 0 rgba(0, 255, 255, 0.8));
+  }
+  60% {
+    transform: translate(-1px, -2px) skewX(-1deg);
+    filter: drop-shadow(0px 0 0 rgba(255, 0, 0, 0.8)) drop-shadow(0px 0 0 rgba(0, 255, 255, 0.8));
+  }
+  80% {
+    transform: translate(3px, -1px) skewX(3deg);
+    filter: drop-shadow(-2px 2px 0 rgba(255, 0, 0, 0.8)) drop-shadow(2px -2px 0 rgba(0, 255, 255, 0.8));
+  }
+  100% {
+    transform: translate(-3px, 1px) skewX(-3deg);
+    filter: drop-shadow(2px -2px 0 rgba(255, 0, 0, 0.8)) drop-shadow(-2px 2px 0 rgba(0, 255, 255, 0.8));
+  }
 }

--- a/src/styles_views.css
+++ b/src/styles_views.css
@@ -136,7 +136,7 @@
 
 .echo-document.echo-recent {
   box-shadow:
-    0 25px 70px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     inset 0 1px 2px rgba(255, 255, 255, 0.2),
     inset 0 0 50px rgba(0, 229, 255, 0.15),
     0 0 30px rgba(0, 229, 255, 0.25);
@@ -206,7 +206,7 @@
     rgba(0, 0, 0, 0.8) 0%,
     rgba(10, 15, 30, 0.4) 100%
   ) !important;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .echo-header::after {
@@ -257,7 +257,7 @@
   font-size: 11px;
   background: hsla(var(--echo-tint, 0deg), 100%, 15%, 0.6);
   padding: 3px 10px;
-  border-radius: 12px;
+  border-radius: 4px;
   border: 1px solid hsla(var(--echo-tint, 0deg), 100%, 50%, 0.3);
   color: hsla(var(--echo-tint, 0deg), 100%, 80%, 1);
   box-shadow: inset 0 0 8px hsla(var(--echo-tint, 0deg), 100%, 50%, 0.2);
@@ -271,7 +271,7 @@
   font-size: 11px;
   background: rgba(0, 0, 0, 0.4);
   padding: 4px 10px;
-  border-radius: 6px;
+  border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.05);
   color: hsla(var(--echo-tint, 0deg), 100%, 70%, 0.9);
   margin-left: auto;
@@ -320,7 +320,7 @@
   user-select: none;
   line-height: 1.6;
   background: rgba(0, 0, 0, 0.2);
-  border-radius: 12px 0 0 12px;
+  border-radius: 4px 0 0 4px;
   margin: 20px 0;
 }
 
@@ -328,7 +328,7 @@
   width: 40px;
   background: rgba(0, 0, 0, 0.15);
   margin: 20px 0 20px 10px;
-  border-radius: 6px;
+  border-radius: 4px;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -368,7 +368,7 @@
 .minimap-block {
   height: 4px;
   background: hsla(var(--echo-tint, 0deg), 100%, 70%, 1);
-  border-radius: 2px;
+  border-radius: 4px;
   box-shadow: 0 0 4px hsla(var(--echo-tint, 0deg), 100%, 70%, 0.4);
   position: relative;
   z-index: 1;
@@ -429,7 +429,7 @@
   word-wrap: break-word;
   background: transparent;
   padding: 16px 20px;
-  border-radius: 0 12px 12px 0;
+  border-radius: 0 4px 4px 0;
   border: 1px solid rgba(255, 255, 255, 0.05);
   border-left: none;
   font-family: var(--font-mono);
@@ -509,7 +509,7 @@
 .echo-peek-btn {
   background: rgba(0, 229, 255, 0.1);
   border: 1px solid rgba(0, 229, 255, 0.3);
-  border-radius: 6px;
+  border-radius: 4px;
   cursor: pointer;
   width: 28px;
   height: 28px;
@@ -549,7 +549,7 @@
   height: 80vh !important;
   transform: translate3d(0, 0, 400px) scale(1) !important;
   box-shadow:
-    0 50px 100px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     0 0 100px rgba(0, 229, 255, 0.4),
     inset 0 0 50px rgba(0, 229, 255, 0.2) !important;
   border-color: #00e5ff !important;
@@ -882,7 +882,7 @@ body.fanning-active .echo-document:not(.peek) {
     )
     rotateZ(var(--fan-rot-z, 0deg)) !important;
   box-shadow:
-    0 30px 60px rgba(0, 0, 0, 0.8),
+    0 4px 12px rgba(0, 0, 0, 0.8),
     0 0 20px rgba(0, 229, 255, 0.3),
     inset 0 0 10px rgba(255, 255, 255, 0.1) !important;
   border-color: rgba(0, 229, 255, 0.5) !important;
@@ -906,7 +906,7 @@ body.fanning-active .echo-document:not(.peek):hover {
     )
     rotateZ(0deg) scale(1.15) !important;
   box-shadow:
-    0 40px 80px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     0 0 40px rgba(0, 229, 255, 0.8),
     inset 0 0 20px rgba(255, 255, 255, 0.4) !important;
   border-color: rgba(0, 229, 255, 1) !important;
@@ -1721,7 +1721,7 @@ body.isometric-active #container > * {
   border: 2px solid rgba(0, 229, 255, 0.4) !important;
   background-color: rgba(10, 15, 25, 0.4) !important;
   box-shadow:
-    0 20px 50px rgba(0, 0, 0, 0.5),
+    0 4px 12px rgba(0, 0, 0, 0.5),
     inset 0 0 30px rgba(0, 229, 255, 0.1) !important;
   backdrop-filter: blur(4px);
   overflow: visible !important;
@@ -1892,7 +1892,7 @@ body.timeline-active .echo-document:hover {
       )
       rotateZ(var(--rot-z, 0deg)) scale(1);
     filter: blur(var(--base-blur, 4px)) brightness(1);
-    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.95);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   }
   20% {
     transform: translate3d(
@@ -1915,7 +1915,7 @@ body.timeline-active .echo-document:hover {
       )
       rotateZ(var(--rot-z, 0deg)) scale(1);
     filter: blur(var(--base-blur, 4px)) brightness(1);
-    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.95);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   }
 }
 
@@ -1967,7 +1967,7 @@ body.x-ray-active .echo-document:hover {
     )
     scale(calc((1.05 + (var(--wake) * 0.08)) * var(--wormhole-scale, 1)));
   box-shadow:
-    0 40px 100px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     inset 0 1px 3px rgba(255, 255, 255, 0.3),
     inset 0 0 50px rgba(255, 255, 255, 0.1),
     0 0 35px hsla(var(--echo-tint, 0deg), 100%, 60%, 0.3);
@@ -2642,7 +2642,7 @@ body.galaxy-active .echo-document:hover {
     )
     rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1.5) !important;
   z-index: 100 !important;
-  border-radius: 8px; /* Return to document shape on hover */
+  border-radius: 4px; /* Return to document shape on hover */
 }
 
 @keyframes galaxy-spin {
@@ -2747,7 +2747,7 @@ body.theater-active #editor {
   z-index: 1000 !important;
   transform: scale(1.05) translateZ(50px) !important;
   box-shadow:
-    0 50px 150px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     0 0 50px rgba(0, 229, 255, 0.3) !important;
   opacity: 1 !important;
   filter: none !important;
@@ -2844,7 +2844,7 @@ body.peel-active .echo-document {
   opacity: 0.8 !important;
   filter: blur(2px) !important;
   box-shadow:
-    0 40px 100px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     inset 0 1px 3px rgba(255, 255, 255, 0.5),
     0 0 40px rgba(0, 229, 255, 0.4);
   border-color: rgba(0, 229, 255, 0.7);
@@ -2926,7 +2926,7 @@ body.peel-active #editor {
   content: "";
   position: absolute;
   inset: -2px;
-  border-radius: 26px;
+  border-radius: 4px;
   padding: 2px;
   background: conic-gradient(
     from var(--neon-angle),
@@ -3069,8 +3069,8 @@ body.peel-active #editor {
   backdrop-filter: blur(60px) saturate(300%);
   -webkit-backdrop-filter: blur(48px) saturate(250%);
   border: 1px solid rgba(0, 255, 255, 0.5);
-  border-radius: 16px;
-  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.95), inset 0 0 45px rgba(0, 255, 255, 0.6), inset 0 1px 3px rgba(255, 255, 255, 0.3), 0 0 25px rgba(0, 255, 255, 0.4);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), inset 0 0 45px rgba(0, 255, 255, 0.6), inset 0 1px 3px rgba(255, 255, 255, 0.3), 0 0 25px rgba(0, 255, 255, 0.4);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -3086,7 +3086,7 @@ body.peel-active #editor {
     rgba(10, 15, 30, 0.55)
   );
   box-shadow:
-    0 35px 70px rgba(0, 0, 0, 0.95),
+    0 4px 12px rgba(0, 0, 0, 0.95),
     0 0 35px rgba(0, 255, 255, 0.35),
     inset 0 0 0 1px rgba(0, 255, 255, 0.5),
     inset 0 1px 3px rgba(255, 255, 255, 0.3);
@@ -3113,7 +3113,7 @@ body.peel-active #editor {
   width: 6px;
   height: 100%;
   background: rgba(255, 255, 255, 0.05);
-  border-radius: 3px;
+  border-radius: 4px;
   outline: none;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.5);
   border: 1px solid rgba(255, 255, 255, 0.05);
@@ -3152,7 +3152,7 @@ body.peel-active #editor {
     scale(1.2) !important;
   z-index: 100 !important;
   box-shadow:
-    0 20px 60px rgba(0, 0, 0, 0.9),
+    0 4px 12px rgba(0, 0, 0, 0.9),
     0 0 40px rgba(0, 229, 255, 0.8),
     inset 0 0 30px rgba(0, 229, 255, 0.4) !important;
   border: 2px solid rgba(0, 229, 255, 0.9) !important;
@@ -3203,14 +3203,14 @@ body:has(.slicer-highlight) .echo-document:not(.slicer-highlight) {
 /* Elevated Peeking State */
 .echo-document.is-peeking {
   box-shadow:
-    0 100px 300px rgba(0, 0, 0, 0.95),
+    0 4px 12px rgba(0, 0, 0, 0.95),
     0 0 100px rgba(0, 229, 255, 0.3),
     inset 0 0 20px rgba(255, 255, 255, 0.1) !important;
   border: 1px solid rgba(0, 229, 255, 0.6) !important;
   background: rgba(10, 15, 25, 0.95) !important;
   backdrop-filter: blur(20px) !important;
   -webkit-backdrop-filter: blur(20px) !important;
-  border-radius: 16px !important;
+  border-radius: 4px !important;
   opacity: 1 !important;
   z-index: 9999 !important;
 }
@@ -3232,7 +3232,7 @@ body.origami-active .echo-document:hover {
   filter: none;
   z-index: 9999 !important;
   box-shadow:
-    0 20px 40px rgba(0, 255, 200, 0.3),
+    0 4px 12px rgba(0, 255, 200, 0.3),
     inset 0 0 10px rgba(255, 255, 255, 0.1);
 }
 
@@ -3277,7 +3277,7 @@ body.origami-active .echo-document:hover {
 #dock button {
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
+  border-radius: 4px;
   color: #fff;
   transition: all 0.3s ease;
   padding: 8px 12px;
@@ -3296,7 +3296,7 @@ body.origami-active .echo-document:hover {
 .tab {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
+  border-radius: 4px;
   margin: 0 2px;
   transition: all 0.3s ease;
 }
@@ -3472,7 +3472,7 @@ body.data-hive-active .echo-document:hover {
   ) !important;
   backdrop-filter: blur(4px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 8px 8px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 
 /* Crystal Lattice View Specifics */
@@ -3624,7 +3624,7 @@ body.fractal-active .echo-document {
   box-shadow:
     0 0 30px rgba(100, 255, 100, 0.2),
     inset 0 0 15px rgba(100, 255, 100, 0.1);
-  border-radius: 12px;
+  border-radius: 4px;
 }
 /* ─── VPS Action Panel ────────────────────────────────────────────────────── */
 .vps-action-panel {
@@ -3645,11 +3645,11 @@ body.fractal-active .echo-document {
   font-size: 13px;
   font-weight: 700;
   padding: 12px 24px;
-  border-radius: 16px; /* Sharper UI corners */
+  border-radius: 4px; /* Sharper UI corners */
   cursor: pointer;
   backdrop-filter: blur(24px) saturate(180%);
   -webkit-backdrop-filter: blur(24px) saturate(180%);
-  box-shadow:0 10px 30px rgba(0, 0, 0, 0.7), inset 0 0 25px rgba(0, 255, 255, 0.3), 0 0 12px rgba(0, 255, 255, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), inset 0 0 25px rgba(0, 255, 255, 0.3), 0 0 12px rgba(0, 255, 255, 0.2);
   transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
   text-shadow: 0 0 5px rgba(0, 255, 255, 0.5), 0 1px 3px rgba(0, 0, 0, 0.9);
 }
@@ -3657,7 +3657,7 @@ body.fractal-active .echo-document {
 .vps-action-btn:hover {
   background: linear-gradient(135deg, rgba(40, 60, 100, 0.95), rgba(20, 30, 60, 0.9));
   border: 1px solid rgba(0, 255, 255, 0.8);
-  box-shadow: 0 12px 35px rgba(0, 255, 255, 0.4), inset 0 0 35px rgba(0, 255, 255, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 255, 255, 0.4), inset 0 0 35px rgba(0, 255, 255, 0.3);
   backdrop-filter: blur(48px) saturate(250%);
   transform: scale(1.06) translateY(-4px);
 }
@@ -3669,7 +3669,7 @@ body.fractal-active .echo-document {
 
 #radar-canvas {
   background: rgba(10, 15, 25, 0.4);
-  border-radius: 8px;
+  border-radius: 4px;
   border: 1px solid rgba(0, 229, 255, 0.2);
   box-shadow: inset 0 0 10px rgba(0, 229, 255, 0.1);
   width: 100%;
@@ -3680,7 +3680,7 @@ body.fractal-active .echo-document {
 #global-search, #theme-select, #rain-sim-backend {
   background: rgba(10, 15, 25, 0.5);
   border: 1px solid rgba(0, 229, 255, 0.2);
-  border-radius: 8px;
+  border-radius: 4px;
   color: #c0c0d0;
   padding: 6px;
   font-family: 'JetBrains Mono', monospace;
@@ -3799,7 +3799,7 @@ body.prismatic-array-active .echo-document {
   transition: transform 0.8s cubic-bezier(0.2, 0.8, 0.2, 1), opacity 0.5s ease, filter 0.5s ease;
   transform: translate3d(var(--tx, 0), var(--ty, 0), var(--tz, 0))
              rotateX(var(--rot-x, 0)) rotateY(var(--rot-y, 0)) rotateZ(var(--rot-z, 0));
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   border: 1px solid rgba(0, 255, 200, 0.3);
   background: rgba(10, 15, 25, 0.8);
   backdrop-filter: blur(8px);
@@ -3810,7 +3810,7 @@ body.prismatic-array-active .echo-document {
 body.prismatic-array-active .echo-document:hover {
   transform: translate3d(var(--tx, 0), var(--ty, 0), calc(var(--tz, 0) + 150px))
              rotateX(0) rotateY(0) rotateZ(0) scale(1.1);
-  box-shadow: 0 20px 60px rgba(0, 255, 200, 0.6);
+  box-shadow: 0 4px 12px rgba(0, 255, 200, 0.4);
   border-color: rgba(0, 255, 200, 0.8);
   z-index: 1000 !important;
   opacity: 1;
@@ -3820,7 +3820,7 @@ body.prismatic-array-active .echo-document:hover {
 body.prismatic-array-active #editor {
   transform: scale(0.85) translateZ(100px);
   opacity: 0.9;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.7);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   transition: all 0.5s ease;
 }
 


### PR DESCRIPTION
This PR improves the overall formatting and look and feel of the web IDE. It creates a sleeker, more professional UI by standardizing to a sharp 4px border-radius and tightening the box-shadow profiles across the `.echo-document`, `#dock`, and other glassmorphism components. 

Additionally, this PR addresses the request to innovate new features interacting with the layers of partially obscured documents by implementing three entirely new interactive lenses:
- **Synapse Connect Lens** (Alt+Shift+7)
- **Ethereal Ghost Lens** (Alt+Shift+8)
- **Holographic Distortion Lens** (Alt+Shift+9)

These lenses use dynamic CSS `mask-image` effects, keyframe animations, and 3D transforms hooked into the existing `InputManager` framework. Testing (`npm run check` and `npm test`) passed.

---
*PR created automatically by Jules for task [8694813270451269494](https://jules.google.com/task/8694813270451269494) started by @ford442*