### PR TITLE
feat: add Nebula Dream, Crystal Resonance, and Abyssal Depth lenses

### DIFF
--- a/src/interactions/lensBindings.js
+++ b/src/interactions/lensBindings.js
@@ -706,6 +706,64 @@ export function registerLensBindings(manager, { doc = document } = {}) {
     onUp: () => body.classList.remove("loupe-active", "chrono-fractal-active"),
   });
 
+
+  manager.register({
+    id: "nebula-dream",
+    category: "lens",
+    description: "Nebula Dream Lens (Alt+Shift+0)",
+    combo: { alt: true, shift: true, code: "Digit0" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "nebula-dream-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "nebula-dream-active"),
+  });
+
+  manager.register({
+    id: "crystal-resonance",
+    category: "lens",
+    description: "Crystal Resonance Lens (Alt+Shift+Minus)",
+    combo: { alt: true, shift: true, code: "Minus" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "crystal-resonance-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "crystal-resonance-active"),
+  });
+
+  manager.register({
+    id: "abyssal-depth",
+    category: "lens",
+    description: "Abyssal Depth Lens (Alt+Shift+P)",
+    combo: { alt: true, shift: true, code: "KeyP" },
+    type: "hold",
+    group: "lens",
+    onDown: () => {
+      body.classList.add("loupe-active", "abyssal-depth-active");
+      const echoLayer = (typeof doc !== "undefined" && doc.getElementById) ? doc.getElementById("echo-layer") : document.getElementById("echo-layer");
+      if (echoLayer) {
+        echoLayer.querySelectorAll(".echo-document").forEach((echoDoc, idx) => {
+          echoDoc.style.setProperty("--item-index", idx);
+        });
+      }
+    },
+    onUp: () => body.classList.remove("loupe-active", "abyssal-depth-active"),
+  });
+
   if (typeof doc.addEventListener === "function") {
     doc.addEventListener("mousemove", (e) => {
       if (!body.classList.contains("loupe-active")) return;

--- a/src/styles_ui.css
+++ b/src/styles_ui.css
@@ -2332,3 +2332,58 @@ body.chrono-fractal-active .echo-document::before {
   pointer-events: none;
   z-index: 5;
 }
+
+
+/* Nebula Dream Lens */
+body.nebula-dream-active #editor {
+  -webkit-mask-image: radial-gradient(circle 200px at var(--lens-x, 50%) var(--lens-y, 50%), transparent 0%, black 100%);
+  mask-image: radial-gradient(circle 200px at var(--lens-x, 50%) var(--lens-y, 50%), transparent 0%, black 100%);
+}
+body.nebula-dream-active .echo-document {
+  transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.2, 1), filter 0.5s ease;
+  transform: translateZ(calc(var(--item-index, 0) * -80px)) rotate(calc(var(--item-index, 0) * 5deg)) scale(calc(1 + var(--item-index, 0) * 0.05));
+  filter: hue-rotate(calc(var(--item-index, 0) * 45deg)) blur(calc(var(--item-index, 0) * 1px)) opacity(calc(1 - var(--item-index, 0) * 0.1));
+  box-shadow: 0 0 30px rgba(138, 43, 226, 0.5);
+  border: 1px solid rgba(255, 105, 180, 0.3);
+}
+
+/* Crystal Resonance Lens */
+body.crystal-resonance-active #editor {
+  -webkit-mask-image: radial-gradient(circle 180px at var(--lens-x, 50%) var(--lens-y, 50%), transparent 10%, black 90%);
+  mask-image: radial-gradient(circle 180px at var(--lens-x, 50%) var(--lens-y, 50%), transparent 10%, black 90%);
+}
+body.crystal-resonance-active .echo-document {
+  transition: transform 0.4s cubic-bezier(0.1, 0.7, 0.1, 1), filter 0.4s ease;
+  transform: translateZ(calc(var(--item-index, 0) * -60px)) rotateZ(calc(var(--item-index, 0) * 15deg)) scale(calc(1 - var(--item-index, 0) * 0.02));
+  filter: contrast(1.5) brightness(1.2) drop-shadow(0 0 10px rgba(0, 255, 255, 0.8)) hue-rotate(calc(var(--item-index, 0) * 15deg));
+  border: 1px solid rgba(0, 255, 255, 0.6);
+  backdrop-filter: blur(4px);
+}
+body.crystal-resonance-active .echo-document::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: linear-gradient(135deg, rgba(255,255,255,0.4) 0%, transparent 50%, rgba(255,255,255,0.1) 100%);
+  pointer-events: none;
+}
+
+/* Abyssal Depth Lens */
+body.abyssal-depth-active #editor {
+  -webkit-mask-image: radial-gradient(circle 250px at var(--lens-x, 50%) var(--lens-y, 50%), transparent 0%, black 80%);
+  mask-image: radial-gradient(circle 250px at var(--lens-x, 50%) var(--lens-y, 50%), transparent 0%, black 80%);
+}
+body.abyssal-depth-active .echo-document {
+  transition: transform 0.6s cubic-bezier(0.25, 0.1, 0.25, 1), filter 0.6s ease;
+  transform: translateY(calc(var(--item-index, 0) * 20px)) translateZ(calc(var(--item-index, 0) * -120px)) scale(calc(1 - var(--item-index, 0) * 0.08));
+  filter: brightness(0.6) sepia(0.8) hue-rotate(180deg) blur(calc(var(--item-index, 0) * 2px));
+  box-shadow: 0 10px 40px rgba(0, 20, 40, 0.8);
+  border: 1px solid rgba(0, 100, 150, 0.2);
+}
+body.abyssal-depth-active .echo-document::after {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0, 50, 100, 0.2);
+  mix-blend-mode: overlay;
+  pointer-events: none;
+}


### PR DESCRIPTION
Added three new interactive lenses (Nebula Dream, Crystal Resonance, and Abyssal Depth) per user preference. These lenses use CSS 3D transforms, filters, and mask images driven by `--item-index` and are triggered by `Alt+Shift+0`, `Alt+Shift+-`, and `Alt+Shift+P`, respectively. Temporary frontend test files have been cleaned up and are not included in the commit.

---
*PR created automatically by Jules for task [18090671714799525687](https://jules.google.com/task/18090671714799525687) started by @ford442*